### PR TITLE
fix: fix jacoco source file paths

### DIFF
--- a/src/handlers/jacocoCoverageHandler.ts
+++ b/src/handlers/jacocoCoverageHandler.ts
@@ -1,6 +1,12 @@
 'use strict';
 
-import { JaCoCoCoverageObject, JaCoCoPackage, JaCoCoSourceFile, JaCoCoLine, CoverageHandler } from '../helpers/types.js';
+import {
+  JaCoCoCoverageObject,
+  JaCoCoPackage,
+  JaCoCoSourceFile,
+  JaCoCoLine,
+  CoverageHandler,
+} from '../helpers/types.js';
 
 export class JaCoCoCoverageHandler implements CoverageHandler {
   private readonly coverageObj: JaCoCoCoverageObject;
@@ -18,11 +24,15 @@ export class JaCoCoCoverageHandler implements CoverageHandler {
   }
 
   public processFile(filePath: string, fileName: string, lines: Record<string, number>): void {
-    const packageName = filePath.split('/')[0]; // Extract root directory as package name
+    const pathParts = filePath.split('/');
+    const fileNamewithExt = pathParts.pop()!;
+    const packageName = pathParts.join('/');
+
     const packageObj = this.getOrCreatePackage(packageName);
 
+    // Ensure source file only contains the filename, not the full path
     const sourceFileObj: JaCoCoSourceFile = {
-      '@name': filePath,
+      '@name': fileNamewithExt,
       line: [],
       counter: [],
     };
@@ -49,7 +59,7 @@ export class JaCoCoCoverageHandler implements CoverageHandler {
       '@type': 'LINE',
       '@missed': totalLines - coveredLines,
       '@covered': coveredLines,
-    });  
+    });
 
     packageObj.sourcefile.push(sourceFileObj);
   }
@@ -69,25 +79,21 @@ export class JaCoCoCoverageHandler implements CoverageHandler {
         packageMissed += sf.counter[0]['@missed'];
       }
 
-      packageObj.counter.push(
-        {
-          '@type': 'LINE',
-          '@missed': packageMissed,
-          '@covered': packageCovered,
-        }
-      );
+      packageObj.counter.push({
+        '@type': 'LINE',
+        '@missed': packageMissed,
+        '@covered': packageCovered,
+      });
 
       overallCovered += packageCovered;
       overallMissed += packageMissed;
     }
 
-    this.coverageObj.report.counter.push(
-      {
-        '@type': 'LINE',
-        '@missed': overallMissed,
-        '@covered': overallCovered,
-      }
-    );
+    this.coverageObj.report.counter.push({
+      '@type': 'LINE',
+      '@missed': overallMissed,
+      '@covered': overallCovered,
+    });
 
     return this.coverageObj;
   }

--- a/test/jacoco_baseline.xml
+++ b/test/jacoco_baseline.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN" "report.dtd">
 <report name="JaCoCo">
-  <package name="force-app">
-    <sourcefile name="force-app/main/default/classes/AccountProfile.cls">
+  <package name="force-app/main/default/classes">
+    <sourcefile name="AccountProfile.cls">
       <line nr="52" mi="1" ci="0" mb="0" cb="0"/>
       <line nr="53" mi="1" ci="0" mb="0" cb="0"/>
       <line nr="54" mi="0" ci="1" mb="0" cb="0"/>
@@ -38,8 +38,8 @@
     </sourcefile>
     <counter type="LINE" missed="4" covered="27"/>
   </package>
-  <package name="packaged">
-    <sourcefile name="packaged/triggers/AccountTrigger.trigger">
+  <package name="packaged/triggers">
+    <sourcefile name="AccountTrigger.trigger">
       <line nr="52" mi="1" ci="0" mb="0" cb="0"/>
       <line nr="53" mi="1" ci="0" mb="0" cb="0"/>
       <line nr="54" mi="0" ci="1" mb="0" cb="0"/>


### PR DESCRIPTION
Confirmed when making this modification locally that SonarQube is able to parse this JaCoCo report and display code coverage % and covered/uncovered lines correctly.