### PR TITLE
feat: add ignore package directories flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,17 @@ The `apex-code-coverage-transformer` has 1 command:
 
 ```
 USAGE
-  $ sf acc-transformer transform -j <value> -r <value> -f <value> [--json]
+  $ sf acc-transformer transform -j <value> -r <value> -f <value> -i <value> [--json]
 
 FLAGS
-  -j, --coverage-json=<value> Path to the code coverage JSON file created by the Salesforce CLI deploy or test command.
-  -r, --output-report=<value> Path to the code coverage file that will be created by this plugin.
-                              [default: "coverage.[xml/info]"]
-  -f, --format=<value>        Output format for the code coverage format.
-                              [default: "sonar"]
+  -j, --coverage-json=<value>             Path to the code coverage JSON file created by the Salesforce CLI deploy or test command.
+  -r, --output-report=<value>             Path to the code coverage file that will be created by this plugin.
+                                          [default: "coverage.[xml/info]"]
+  -f, --format=<value>                    Output format for the code coverage format.
+                                          [default: "sonar"]
+  -i, --ignore-package-directory=<value>  Package directories to ignore when looking for matching files in the coverage report.
+                                          Should be as they appear in the "sfdx-project.json".
+                                          Can be declared multiple times.
 
 GLOBAL FLAGS
   --json  Format output as json.
@@ -110,6 +113,8 @@ EXAMPLES
     $ sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "clover"
 
     $ sf acc-transformer transform -j "coverage.json" -r "coverage.info" -f "lcovonly"
+
+    $ sf acc-transformer transform -j "coverage.json" -i "force-app"
 ```
 
 ## Coverage Report Formats

--- a/messages/transformer.transform.md
+++ b/messages/transformer.transform.md
@@ -12,6 +12,7 @@ Transform Salesforce Apex code coverage JSONs created during deployments and tes
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "cobertura"`
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "clover"`
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.info" -f "lcovonly"`
+- `sf acc-transformer transform -j "coverage.json" -i "force-app"`
 
 # flags.coverage-json.summary
 
@@ -24,3 +25,7 @@ Path to the code coverage file that will be created by this plugin.
 # flags.format.summary
 
 Output format for the coverage report.
+
+# flags.ignore-package-directory.summary
+
+Ignore a package directory when looking for matching files in the coverage report.

--- a/src/commands/acc-transformer/transform.ts
+++ b/src/commands/acc-transformer/transform.ts
@@ -39,18 +39,25 @@ export default class TransformerTransform extends SfCommand<TransformerTransform
       default: 'sonar',
       options: formatOptions,
     }),
+    'ignore-package-directory': Flags.directory({
+      summary: messages.getMessage('flags.ignore-package-directory.summary'),
+      char: 'i',
+      required: false,
+      multiple: true,
+    }),
   };
 
   public async run(): Promise<TransformerTransformResult> {
     const { flags } = await this.parse(TransformerTransform);
     const jsonFilePath = resolve(flags['coverage-json']);
     let outputReportPath = resolve(flags['output-report']);
+    const ignoreDirs = flags['ignore-package-directory'] ?? [];
     const format = flags['format'];
     let jsonData: string;
     try {
       jsonData = await readFile(jsonFilePath, 'utf-8');
     } catch (error) {
-      this.warn(`Failed to read ${jsonFilePath}. Confirm file exists.`)
+      this.warn(`Failed to read ${jsonFilePath}. Confirm file exists.`);
       return { path: jsonFilePath };
     }
 
@@ -62,12 +69,12 @@ export default class TransformerTransform extends SfCommand<TransformerTransform
 
     // Determine the type of coverage data using type guards
     if (commandType === 'TestCoverageData') {
-      const result = await transformTestCoverageReport(parsedData as TestCoverageData[], format);
+      const result = await transformTestCoverageReport(parsedData as TestCoverageData[], format, ignoreDirs);
       xmlData = result.xml;
       warnings = result.warnings;
       filesProcessed = result.filesProcessed;
     } else if (commandType === 'DeployCoverageData') {
-      const result = await transformDeployCoverageReport(parsedData as DeployCoverageData, format);
+      const result = await transformDeployCoverageReport(parsedData as DeployCoverageData, format, ignoreDirs);
       xmlData = result.xml;
       warnings = result.warnings;
       filesProcessed = result.filesProcessed;

--- a/src/helpers/getPackageDirectories.ts
+++ b/src/helpers/getPackageDirectories.ts
@@ -6,7 +6,9 @@ import { resolve } from 'node:path';
 import { SfdxProject } from './types.js';
 import { getRepoRoot } from './getRepoRoot.js';
 
-export async function getPackageDirectories(): Promise<{ repoRoot: string; packageDirectories: string[] }> {
+export async function getPackageDirectories(
+  ignoreDirectories: string[] = []
+): Promise<{ repoRoot: string; packageDirectories: string[] }> {
   const { repoRoot, dxConfigFilePath } = await getRepoRoot();
 
   if (!repoRoot || !dxConfigFilePath) {
@@ -15,6 +17,10 @@ export async function getPackageDirectories(): Promise<{ repoRoot: string; packa
 
   const sfdxProjectRaw: string = await readFile(dxConfigFilePath, 'utf-8');
   const sfdxProject: SfdxProject = JSON.parse(sfdxProjectRaw) as SfdxProject;
-  const packageDirectories = sfdxProject.packageDirectories.map((directory) => resolve(repoRoot, directory.path));
+
+  const packageDirectories = sfdxProject.packageDirectories
+    .filter((directory) => !ignoreDirectories.includes(directory.path)) // Ignore exact folder names
+    .map((directory) => resolve(repoRoot, directory.path));
+
   return { repoRoot, packageDirectories };
 }

--- a/src/helpers/transformTestCoverageReport.ts
+++ b/src/helpers/transformTestCoverageReport.ts
@@ -11,11 +11,12 @@ import { getConcurrencyThreshold } from './getConcurrencyThreshold.js';
 
 export async function transformTestCoverageReport(
   testCoverageData: TestCoverageData[],
-  format: string
+  format: string,
+  ignoreDirs: string[]
 ): Promise<{ xml: string; warnings: string[]; filesProcessed: number }> {
   const warnings: string[] = [];
   let filesProcessed = 0;
-  const { repoRoot, packageDirectories } = await getPackageDirectories();
+  const { repoRoot, packageDirectories } = await getPackageDirectories(ignoreDirs);
   const handler = getCoverageHandler(format);
 
   // Ensure testCoverageData is an array


### PR DESCRIPTION
Add a new flag to allow users to specify package directories to ignore as they are listed in the `sfdx-project.json` file, i.e. "force-app".

Might be useful if there's a use-case where 2 package directories have files with the same names, but you only need to run code coverage checks against 1 directory.