### PR TITLE
feat: add markdown and github-actions output formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A Salesforce CLI plugin that converts Apex code coverage JSON (from deploy or test runs) into formats used by SonarQube, Codecov, GitHub, GitLab, Azure DevOps, Bitbucket, and other tools. Use it to keep coverage in sync with your CI/CD and code quality pipelines.
 
+It also produces presentation-ready output for pull-request reviews: a Markdown summary for PR/MR comments and CI job summaries, and GitHub Actions workflow command annotations that surface uncovered lines inline on the PR diff. The GitHub Actions output is designed to pair with the Apex code quality annotations from [sf-cat](https://www.npmjs.com/package/sf-cat), so a single PR can show coverage gaps and quality findings side-by-side.
+
 > Missing an output format via `--format`? Open an [issue](https://github.com/mcarvin8/apex-code-coverage-transformer/issues) or submit a [pull request](https://github.com/mcarvin8/apex-code-coverage-transformer/blob/main/CONTRIBUTING.md).
 
 <!-- TABLE OF CONTENTS -->
@@ -45,7 +47,7 @@ A Salesforce CLI plugin that converts Apex code coverage JSON (from deploy or te
 ## Install
 
 ```bash
-sf plugins install apex-code-coverage-transformer@x.y.z
+sf plugins install apex-code-coverage-transformer@latest
 ```
 
 ## Quick Start
@@ -86,6 +88,8 @@ sf plugins install apex-code-coverage-transformer@x.y.z
 This plugin is for Salesforce DX projects (`sfdx-project.json`). It maps Apex names in the CLI coverage JSON to file paths in your package directories and only includes files that exist in those directories. Apex from managed or unlocked packages (not in your repo) is excluded and reported with a [warning](#troubleshooting).
 
 To run transformation automatically after deploy or test commands, use the [Hook](#automatic-transformation-hook).
+
+> **Tip — diff-scoped coverage on PRs.** The Salesforce CLI already scopes `sf project deploy validate`/`start` coverage to whatever is in the deployed manifest. If your PR pipeline builds a manifest from the git diff (for example with [sfdx-git-delta](https://github.com/scolladon/sfdx-git-delta)) and then runs `sf project deploy validate --coverage-formatters json --manifest <delta>`, the resulting coverage JSON only contains the changed Apex. Running this plugin against that JSON gives you per-PR coverage with no extra flags — the diff scoping happens upstream in the deployment, not here.
 
 ### Salesforce CLI
 
@@ -143,18 +147,20 @@ GLOBAL FLAGS
 
 Use `-f` / `--format` to choose the output format. Multiple `-f` values produce multiple files with the format in the name (e.g. `coverage-sonar.xml`, `coverage-cobertura.xml`).
 
-| Format       | Description                | Typical use                             | Example                                                                                |
-| ------------ | -------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------- |
-| sonar        | SonarQube generic coverage | SonarQube, SonarCloud                   | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "sonar"`         |
-| cobertura    | Cobertura XML              | Codecov, Azure, Jenkins, GitLab, GitHub | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "cobertura"`     |
-| jacoco       | JaCoCo XML                 | Codecov, Jenkins, Maven, Gradle         | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "jacoco"`        |
-| lcovonly     | LCOV                       | Codecov, Coveralls, GitHub              | `sf acc-transformer transform -j "coverage.json" -r "coverage.info" -f "lcovonly"`     |
-| clover       | Clover XML                 | Bamboo, Bitbucket, Jenkins              | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "clover"`        |
-| json         | Istanbul JSON              | Istanbul/NYC, Codecov                   | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "json"`         |
-| json-summary | JSON summary               | Badges, PR comments                     | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "json-summary"` |
-| simplecov    | SimpleCov JSON             | Codecov, Ruby tools                     | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "simplecov"`    |
-| opencover    | OpenCover XML              | Azure DevOps, VS, Codecov               | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "opencover"`     |
-| html         | HTML report                | Browsers, CI artifacts                  | `sf acc-transformer transform -j "coverage.json" -r "coverage.html" -f "html"`         |
+| Format         | Description                | Typical use                             | Example                                                                                 |
+| -------------- | -------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------- |
+| sonar          | SonarQube generic coverage | SonarQube, SonarCloud                   | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "sonar"`          |
+| cobertura      | Cobertura XML              | Codecov, Azure, Jenkins, GitLab, GitHub | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "cobertura"`      |
+| jacoco         | JaCoCo XML                 | Codecov, Jenkins, Maven, Gradle         | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "jacoco"`         |
+| lcovonly       | LCOV                       | Codecov, Coveralls, GitHub              | `sf acc-transformer transform -j "coverage.json" -r "coverage.info" -f "lcovonly"`      |
+| clover         | Clover XML                 | Bamboo, Bitbucket, Jenkins              | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "clover"`         |
+| json           | Istanbul JSON              | Istanbul/NYC, Codecov                   | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "json"`          |
+| json-summary   | JSON summary               | Badges, PR comments                     | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "json-summary"`  |
+| simplecov      | SimpleCov JSON             | Codecov, Ruby tools                     | `sf acc-transformer transform -j "coverage.json" -r "coverage.json" -f "simplecov"`     |
+| opencover      | OpenCover XML              | Azure DevOps, VS, Codecov               | `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "opencover"`      |
+| html           | HTML report                | Browsers, CI artifacts                  | `sf acc-transformer transform -j "coverage.json" -r "coverage.html" -f "html"`          |
+| markdown       | Markdown summary           | PR/MR comments, CI job summaries        | `sf acc-transformer transform -j "coverage.json" -r "coverage.md" -f "markdown"`        |
+| github-actions | GitHub Actions annotations | GitHub Actions PR diff annotations      | `sf acc-transformer transform -j "coverage.json" -r "coverage.txt" -f "github-actions"` |
 
 ## CI/CD Integration
 
@@ -198,7 +204,7 @@ jobs:
 
 ### SonarQube
 
-Use the **sonar** format and upload using SonarQube's generic test coverage report formatter, `sonar.coverageReportPaths`. 
+Use the **sonar** format and upload using SonarQube's generic test coverage report formatter, `sonar.coverageReportPaths`.
 
 **Scanner:**
 
@@ -289,6 +295,48 @@ jobs:
           path: code-coverage-results.md
 ```
 
+#### Markdown PR comments (built-in)
+
+Skip the third-party summary action by using the built-in `markdown` format. The output is ready to drop straight into a PR comment or the GitHub Actions [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary):
+
+```yaml
+- name: Run Apex Tests
+  run: sf apex run test --code-coverage --output-dir coverage --target-org ci-org
+- name: Transform Coverage to Markdown
+  run: sf acc-transformer transform -j "coverage/test-result-codecoverage.json" -r "coverage.md" -f "markdown"
+- name: Add coverage to job summary
+  run: cat coverage.md >> $GITHUB_STEP_SUMMARY
+- name: Add Coverage PR Comment
+  uses: marocchino/sticky-pull-request-comment@v2
+  if: github.event_name == 'pull_request'
+  with:
+    recreate: true
+    path: coverage.md
+```
+
+The Markdown report includes an overall summary block, a per-package-directory table, and a file-level table sorted with the lowest coverage first so reviewers see the most actionable rows at the top.
+
+#### GitHub Actions inline annotations
+
+The `github-actions` format emits one [`::warning`](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions) workflow command per uncovered Apex line, plus a `::notice` summary. When a step prints the file to stdout, the runner renders annotations inline on the PR diff and on the workflow run page.
+
+```yaml
+- name: Run Apex Tests
+  run: sf apex run test --code-coverage --output-dir coverage --target-org ci-org
+- name: Transform Coverage to GitHub Actions Annotations
+  run: sf acc-transformer transform -j "coverage/test-result-codecoverage.json" -r "coverage.txt" -f "github-actions"
+- name: Emit coverage annotations
+  run: cat coverage.txt
+```
+
+This pairs with the [`sf-cat`](https://www.npmjs.com/package/sf-cat) plugin's GitHub Actions output for code quality findings, so a single PR shows coverage gaps and quality issues as inline annotations on the same diff.
+
+You can produce both at once with multiple `-f` flags:
+
+```bash
+sf acc-transformer transform -j "coverage/test-result-codecoverage.json" -f "markdown" -f "github-actions" -f "sonar"
+```
+
 ### GitLab CI
 
 Cobertura for coverage in the UI:
@@ -342,13 +390,13 @@ Create `.apexcodecovtransformer.config.json` in the project root to transform co
 
 Sample configs: [Salesforce CLI](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/defaults/salesforce-cli/.apexcodecovtransformer.config.json), [SFDX Hardis](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/defaults/sfdx-hardis/.apexcodecovtransformer.config.json).
 
-| Key                        | Required   | Description                                              |
-| -------------------------- | ---------- | -------------------------------------------------------- |
-| `deployCoverageJsonPath`   | For deploy | Path to deploy coverage JSON.                            |
-| `testCoverageJsonPath`     | For test   | Path to test coverage JSON.                              |
+| Key                        | Required   | Description                                                  |
+| -------------------------- | ---------- | ------------------------------------------------------------ |
+| `deployCoverageJsonPath`   | For deploy | Path to deploy coverage JSON.                                |
+| `testCoverageJsonPath`     | For test   | Path to test coverage JSON.                                  |
 | `outputReportPath`         | No         | Output path (default: `coverage.[xml/info/json]` by format). |
-| `format`                   | No         | Format(s), comma-separated (default: `sonar`).           |
-| `ignorePackageDirectories` | No         | Comma-separated package directories to ignore.           |
+| `format`                   | No         | Format(s), comma-separated (default: `sonar`).               |
+| `ignorePackageDirectories` | No         | Comma-separated package directories to ignore.               |
 
 ## Troubleshooting
 
@@ -384,8 +432,8 @@ Error (1): ENOENT: no such file or directory: {packageDir}
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](https://github.com/mcarvin8/apex-code-coverage-transformer/blob/main/CONTRIBUTING.md) for setup, testing, and how to add new coverage formats.
+Contributions are welcome. See [CONTRIBUTING.md](https://github.com/mcarvin8/apex-code-coverage-transformer/blob/main/CONTRIBUTING.md).
 
 ## License
 
-MIT. See [LICENSE](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/LICENSE.md).
+[MIT](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/LICENSE.md)

--- a/messages/transformer.transform.md
+++ b/messages/transformer.transform.md
@@ -12,6 +12,8 @@ Transform Salesforce Apex code coverage JSONs created during deployments and tes
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "cobertura"`
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.xml" -f "clover"`
 - `sf acc-transformer transform -j "coverage.json" -r "coverage.info" -f "lcovonly"`
+- `sf acc-transformer transform -j "coverage.json" -r "coverage.md" -f "markdown"`
+- `sf acc-transformer transform -j "coverage.json" -r "coverage.txt" -f "github-actions"`
 - `sf acc-transformer transform -j "coverage.json" -i "force-app"`
 
 # flags.coverage-json.summary

--- a/src/handlers/BaseHandler.ts
+++ b/src/handlers/BaseHandler.ts
@@ -12,6 +12,8 @@ import {
   SimpleCovCoverageObject,
   OpenCoverCoverageObject,
   HtmlCoverageObject,
+  MarkdownCoverageObject,
+  GitHubActionsCoverageObject,
 } from '../utils/types.js';
 
 /**
@@ -91,7 +93,7 @@ export abstract class BaseHandler implements CoverageHandler {
     filePath: string,
     fileName: string,
     lines: Record<string, number>,
-    sourceContent?: string
+    sourceContent?: string,
   ): void;
 
   public abstract finalize():
@@ -104,5 +106,7 @@ export abstract class BaseHandler implements CoverageHandler {
     | JsonSummaryCoverageObject
     | SimpleCovCoverageObject
     | OpenCoverCoverageObject
-    | HtmlCoverageObject;
+    | HtmlCoverageObject
+    | MarkdownCoverageObject
+    | GitHubActionsCoverageObject;
 }

--- a/src/handlers/getHandler.ts
+++ b/src/handlers/getHandler.ts
@@ -14,6 +14,8 @@ import './jsonSummary.js';
 import './simplecov.js';
 import './opencover.js';
 import './html.js';
+import './markdown.js';
+import './githubActions.js';
 
 /**
  * Get a coverage handler for the specified format.

--- a/src/handlers/githubActions.ts
+++ b/src/handlers/githubActions.ts
@@ -1,0 +1,92 @@
+'use strict';
+
+import { GitHubActionsCoverageObject } from '../utils/types.js';
+import { BaseHandler } from './BaseHandler.js';
+import { HandlerRegistry } from './HandlerRegistry.js';
+
+/**
+ * Handler for generating GitHub Actions workflow command output.
+ *
+ * Emits one `::warning file=...,line=...` annotation per uncovered Apex line
+ * plus a `::notice` summary line. When the resulting file is printed to stdout
+ * by a workflow step, the GitHub Actions runner renders the annotations
+ * inline on the PR diff and on the workflow run page.
+ *
+ * Pairs with the existing `sf-cat` plugin's GitHub Actions output for code
+ * quality, giving Salesforce teams a unified annotation experience for
+ * coverage and quality on the same PR.
+ *
+ * @see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+ *
+ * @example
+ * ```yaml
+ * - name: Transform coverage to GitHub Actions annotations
+ *   run: sf acc-transformer transform -j coverage.json -r coverage.txt -f github-actions
+ * - name: Emit annotations
+ *   run: cat coverage.txt
+ * ```
+ */
+export class GitHubActionsCoverageHandler extends BaseHandler {
+  private readonly coverageObj: GitHubActionsCoverageObject;
+  private totalLinesAccumulator = 0;
+  private coveredLinesAccumulator = 0;
+  private fileCount = 0;
+
+  public constructor() {
+    super();
+    this.coverageObj = {
+      summary: {
+        totalLines: 0,
+        coveredLines: 0,
+        uncoveredLines: 0,
+        lineRate: 0,
+        fileCount: 0,
+      },
+      uncoveredLines: [],
+    };
+  }
+
+  public processFile(filePath: string, _fileName: string, lines: Record<string, number>): void {
+    const { totalLines, coveredLines } = this.calculateCoverage(lines);
+
+    this.totalLinesAccumulator += totalLines;
+    this.coveredLinesAccumulator += coveredLines;
+    this.fileCount += 1;
+
+    const uncovered = this.extractLinesByStatus(lines, false);
+    for (const lineNumber of uncovered) {
+      this.coverageObj.uncoveredLines.push({ filePath, lineNumber });
+    }
+  }
+
+  public finalize(): GitHubActionsCoverageObject {
+    const totalLines = this.totalLinesAccumulator;
+    const coveredLines = this.coveredLinesAccumulator;
+    const uncoveredLines = totalLines - coveredLines;
+    const lineRate = totalLines > 0 ? coveredLines / totalLines : 0;
+
+    this.coverageObj.summary = {
+      totalLines,
+      coveredLines,
+      uncoveredLines,
+      lineRate,
+      fileCount: this.fileCount,
+    };
+
+    this.coverageObj.uncoveredLines.sort((a, b) => {
+      const pathCompare = a.filePath.localeCompare(b.filePath);
+      if (pathCompare !== 0) return pathCompare;
+      return a.lineNumber - b.lineNumber;
+    });
+
+    return this.coverageObj;
+  }
+}
+
+HandlerRegistry.register({
+  name: 'github-actions',
+  description: 'GitHub Actions workflow command annotations for uncovered lines',
+  fileExtension: '.txt',
+  handler: () => new GitHubActionsCoverageHandler(),
+  compatibleWith: ['GitHub Actions'],
+});

--- a/src/handlers/markdown.ts
+++ b/src/handlers/markdown.ts
@@ -1,0 +1,119 @@
+'use strict';
+
+import { MarkdownCoverageObject, MarkdownFileRow, MarkdownPackageRow } from '../utils/types.js';
+import { BaseHandler } from './BaseHandler.js';
+import { HandlerRegistry } from './HandlerRegistry.js';
+
+type PackageAccumulator = { totalLines: number; coveredLines: number; fileCount: number };
+
+/**
+ * Handler for generating Markdown coverage summaries.
+ *
+ * Designed for pipeline PR / MR comments and job summary blocks
+ * (e.g. `$GITHUB_STEP_SUMMARY`, GitLab MR widgets, Bitbucket comments).
+ *
+ * The report includes:
+ * - An overall coverage summary block
+ * - A per-package-directory coverage table
+ * - A file coverage table sorted with the lowest coverage first
+ *
+ * Compatible with:
+ * - GitHub Actions (job summary, sticky PR comments)
+ * - GitLab CI (MR comments)
+ * - Bitbucket / Azure DevOps PR comments
+ * - Any tool that renders GitHub-flavored Markdown
+ */
+export class MarkdownCoverageHandler extends BaseHandler {
+  private readonly coverageObj: MarkdownCoverageObject;
+  private totalLinesAccumulator = 0;
+  private coveredLinesAccumulator = 0;
+  private readonly packageMap = new Map<string, PackageAccumulator>();
+
+  public constructor() {
+    super();
+    this.coverageObj = {
+      summary: {
+        totalLines: 0,
+        coveredLines: 0,
+        uncoveredLines: 0,
+        lineRate: 0,
+        fileCount: 0,
+      },
+      packages: [],
+      files: [],
+    };
+  }
+
+  public processFile(filePath: string, _fileName: string, lines: Record<string, number>): void {
+    const { totalLines, coveredLines, uncoveredLines, lineRate } = this.calculateCoverage(lines);
+
+    const fileRow: MarkdownFileRow = {
+      filePath,
+      totalLines,
+      coveredLines,
+      uncoveredLines,
+      lineRate,
+    };
+
+    this.coverageObj.files.push(fileRow);
+
+    this.totalLinesAccumulator += totalLines;
+    this.coveredLinesAccumulator += coveredLines;
+
+    const directory = filePath.split('/')[0];
+    const existing = this.packageMap.get(directory);
+    if (existing) {
+      existing.totalLines += totalLines;
+      existing.coveredLines += coveredLines;
+      existing.fileCount += 1;
+    } else {
+      this.packageMap.set(directory, { totalLines, coveredLines, fileCount: 1 });
+    }
+  }
+
+  public finalize(): MarkdownCoverageObject {
+    const totalLines = this.totalLinesAccumulator;
+    const coveredLines = this.coveredLinesAccumulator;
+    const uncoveredLines = totalLines - coveredLines;
+    const lineRate = totalLines > 0 ? coveredLines / totalLines : 0;
+
+    this.coverageObj.summary = {
+      totalLines,
+      coveredLines,
+      uncoveredLines,
+      lineRate,
+      fileCount: this.coverageObj.files.length,
+    };
+
+    this.coverageObj.packages = Array.from(this.packageMap.entries())
+      .map(([directory, acc]): MarkdownPackageRow => {
+        const pkgUncovered = acc.totalLines - acc.coveredLines;
+        const pkgLineRate = acc.totalLines > 0 ? acc.coveredLines / acc.totalLines : 0;
+        return {
+          directory,
+          fileCount: acc.fileCount,
+          totalLines: acc.totalLines,
+          coveredLines: acc.coveredLines,
+          uncoveredLines: pkgUncovered,
+          lineRate: pkgLineRate,
+        };
+      })
+      .sort((a, b) => a.directory.localeCompare(b.directory));
+
+    // Worst-covered files first (most actionable in a PR comment), tiebreak by path
+    this.coverageObj.files.sort((a, b) => {
+      if (a.lineRate !== b.lineRate) return a.lineRate - b.lineRate;
+      return a.filePath.localeCompare(b.filePath);
+    });
+
+    return this.coverageObj;
+  }
+}
+
+HandlerRegistry.register({
+  name: 'markdown',
+  description: 'Markdown summary for PR comments and CI job summaries',
+  fileExtension: '.md',
+  handler: () => new MarkdownCoverageHandler(),
+  compatibleWith: ['GitHub Actions', 'GitLab CI', 'Bitbucket', 'Azure DevOps'],
+});

--- a/src/transformers/generators/generateGitHubActions.ts
+++ b/src/transformers/generators/generateGitHubActions.ts
@@ -1,0 +1,51 @@
+import { GitHubActionsCoverageObject } from '../../utils/types.js';
+
+export function isGitHubActionsCoverageObject(obj: unknown): obj is GitHubActionsCoverageObject {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'summary' in obj &&
+    'uncoveredLines' in obj &&
+    Array.isArray((obj as GitHubActionsCoverageObject).uncoveredLines)
+  );
+}
+
+function formatPercent(lineRate: number): string {
+  return `${(lineRate * 100).toFixed(2)}%`;
+}
+
+/**
+ * Escape a string for use as a GitHub Actions workflow command property value.
+ *
+ * @see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#example-setting-a-warning-message
+ */
+function escapeProperty(value: string): string {
+  return value
+    .replace(/%/g, '%25')
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+    .replace(/:/g, '%3A')
+    .replace(/,/g, '%2C');
+}
+
+function escapeData(value: string): string {
+  return value.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+export function generateGitHubActions(coverageObj: GitHubActionsCoverageObject): string {
+  const { summary, uncoveredLines } = coverageObj;
+  const overall = formatPercent(summary.lineRate);
+
+  const summaryLine = `::notice title=Apex Code Coverage::Overall coverage ${escapeData(
+    overall,
+  )} (${summary.coveredLines}/${summary.totalLines} lines, ${summary.uncoveredLines} uncovered across ${
+    summary.fileCount
+  } file${summary.fileCount === 1 ? '' : 's'})`;
+
+  const annotations = uncoveredLines.map(
+    ({ filePath, lineNumber }) =>
+      `::warning file=${escapeProperty(filePath)},line=${lineNumber},title=Uncovered Apex line::Line ${lineNumber} is not covered by any Apex test`,
+  );
+
+  return [summaryLine, ...annotations].join('\n');
+}

--- a/src/transformers/generators/generateGitHubActions.ts
+++ b/src/transformers/generators/generateGitHubActions.ts
@@ -1,15 +1,5 @@
 import { GitHubActionsCoverageObject } from '../../utils/types.js';
 
-export function isGitHubActionsCoverageObject(obj: unknown): obj is GitHubActionsCoverageObject {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    'summary' in obj &&
-    'uncoveredLines' in obj &&
-    Array.isArray((obj as GitHubActionsCoverageObject).uncoveredLines)
-  );
-}
-
 function formatPercent(lineRate: number): string {
   return `${(lineRate * 100).toFixed(2)}%`;
 }

--- a/src/transformers/generators/generateHtml.ts
+++ b/src/transformers/generators/generateHtml.ts
@@ -1,9 +1,5 @@
 import { HtmlCoverageObject } from '../../utils/types.js';
 
-export function isHtmlCoverageObject(obj: unknown): obj is HtmlCoverageObject {
-  return typeof obj === 'object' && obj !== null && 'summary' in obj && 'files' in obj;
-}
-
 function getCoverageColor(lineRate: number): string {
   if (lineRate >= 0.8) return '#4caf50';
   if (lineRate >= 0.6) return '#ff9800';

--- a/src/transformers/generators/generateMarkdown.ts
+++ b/src/transformers/generators/generateMarkdown.ts
@@ -1,16 +1,5 @@
 import { MarkdownCoverageObject } from '../../utils/types.js';
 
-export function isMarkdownCoverageObject(obj: unknown): obj is MarkdownCoverageObject {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    'summary' in obj &&
-    'packages' in obj &&
-    'files' in obj &&
-    Array.isArray((obj as MarkdownCoverageObject).packages)
-  );
-}
-
 function formatPercent(lineRate: number): string {
   return `${(lineRate * 100).toFixed(2)}%`;
 }

--- a/src/transformers/generators/generateMarkdown.ts
+++ b/src/transformers/generators/generateMarkdown.ts
@@ -1,0 +1,68 @@
+import { MarkdownCoverageObject } from '../../utils/types.js';
+
+export function isMarkdownCoverageObject(obj: unknown): obj is MarkdownCoverageObject {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'summary' in obj &&
+    'packages' in obj &&
+    'files' in obj &&
+    Array.isArray((obj as MarkdownCoverageObject).packages)
+  );
+}
+
+function formatPercent(lineRate: number): string {
+  return `${(lineRate * 100).toFixed(2)}%`;
+}
+
+function escapePipes(value: string): string {
+  return value.replace(/\|/g, '\\|');
+}
+
+function buildPackageTable(packages: MarkdownCoverageObject['packages']): string {
+  if (packages.length === 0) return '';
+  const header = [
+    '| Directory | Files | Lines | Covered | Uncovered | Coverage |',
+    '| --- | ---: | ---: | ---: | ---: | ---: |',
+  ].join('\n');
+  const rows = packages
+    .map(
+      (pkg) =>
+        `| ${escapePipes(pkg.directory)} | ${pkg.fileCount} | ${pkg.totalLines} | ${pkg.coveredLines} | ${
+          pkg.uncoveredLines
+        } | ${formatPercent(pkg.lineRate)} |`,
+    )
+    .join('\n');
+  return `## Package directory coverage\n\n${header}\n${rows}`;
+}
+
+function buildFileTable(files: MarkdownCoverageObject['files']): string {
+  if (files.length === 0) return '';
+  const header = ['| File | Lines | Covered | Uncovered | Coverage |', '| --- | ---: | ---: | ---: | ---: |'].join(
+    '\n',
+  );
+  const rows = files
+    .map(
+      (file) =>
+        `| ${escapePipes(file.filePath)} | ${file.totalLines} | ${file.coveredLines} | ${
+          file.uncoveredLines
+        } | ${formatPercent(file.lineRate)} |`,
+    )
+    .join('\n');
+  return `## File coverage\n\nFiles are sorted with the lowest coverage first.\n\n${header}\n${rows}`;
+}
+
+export function generateMarkdown(coverageObj: MarkdownCoverageObject): string {
+  const { summary, packages, files } = coverageObj;
+  const overall = formatPercent(summary.lineRate);
+  const summaryBlock = [
+    '# Apex Code Coverage Report',
+    '',
+    `**Overall coverage:** ${overall} (${summary.coveredLines} / ${summary.totalLines} lines across ${summary.fileCount} file${
+      summary.fileCount === 1 ? '' : 's'
+    })`,
+  ].join('\n');
+
+  const sections = [summaryBlock, buildPackageTable(packages), buildFileTable(files)].filter(Boolean);
+  return sections.join('\n\n');
+}

--- a/src/transformers/reportGenerator.ts
+++ b/src/transformers/reportGenerator.ts
@@ -2,17 +2,42 @@ import { writeFile } from 'node:fs/promises';
 import { extname, basename, dirname, join } from 'node:path';
 import XMLBuilder from 'fast-xml-builder';
 
-import { AnyCoverageObject, LcovCoverageObject } from '../utils/types.js';
+import {
+  AnyCoverageObject,
+  LcovCoverageObject,
+  HtmlCoverageObject,
+  MarkdownCoverageObject,
+  GitHubActionsCoverageObject,
+} from '../utils/types.js';
 import { HandlerRegistry } from '../handlers/HandlerRegistry.js';
 import { builderOptions, XML_HEADER_CONFIG } from '../utils/constants.js';
 import { XmlReportFormat } from '../utils/types.js';
-import { generateHtml, isHtmlCoverageObject } from './generators/generateHtml.js';
-import { generateMarkdown, isMarkdownCoverageObject } from './generators/generateMarkdown.js';
-import { generateGitHubActions, isGitHubActionsCoverageObject } from './generators/generateGitHubActions.js';
+import { generateHtml } from './generators/generateHtml.js';
+import { generateMarkdown } from './generators/generateMarkdown.js';
+import { generateGitHubActions } from './generators/generateGitHubActions.js';
 
 function isXmlReportFormat(format: string): format is XmlReportFormat {
   return format in XML_HEADER_CONFIG;
 }
+
+/**
+ * Dispatch table for formats whose final content is plain text or JSON.
+ *
+ * The format string is validated at the CLI flag level via the
+ * `HandlerRegistry`, and each handler emits the matching coverage object
+ * shape, so a runtime cast is safe here. Centralising the dispatch keeps
+ * `generateReportContent` to a single decision point and avoids a long
+ * chain of `format === ... && isXObject(...)` guards.
+ */
+const STRING_FORMAT_RENDERERS: Record<string, (obj: AnyCoverageObject) => string> = {
+  lcovonly: (obj) => generateLcov(obj as LcovCoverageObject),
+  html: (obj) => generateHtml(obj as HtmlCoverageObject),
+  markdown: (obj) => generateMarkdown(obj as MarkdownCoverageObject),
+  'github-actions': (obj) => generateGitHubActions(obj as GitHubActionsCoverageObject),
+  json: (obj) => JSON.stringify(obj, null, 2),
+  'json-summary': (obj) => JSON.stringify(obj, null, 2),
+  simplecov: (obj) => JSON.stringify(obj, null, 2),
+};
 
 export async function generateAndWriteReport(
   outputPath: string,
@@ -34,26 +59,11 @@ export async function generateAndWriteReport(
 }
 
 function generateReportContent(coverageObj: AnyCoverageObject, format: string): string {
-  if (format === 'lcovonly' && isLcovCoverageObject(coverageObj)) {
-    return generateLcov(coverageObj);
-  }
+  const renderer = STRING_FORMAT_RENDERERS[format];
+  return renderer ? renderer(coverageObj) : generateXmlContent(coverageObj, format);
+}
 
-  if (format === 'html' && isHtmlCoverageObject(coverageObj)) {
-    return generateHtml(coverageObj);
-  }
-
-  if (format === 'markdown' && isMarkdownCoverageObject(coverageObj)) {
-    return generateMarkdown(coverageObj);
-  }
-
-  if (format === 'github-actions' && isGitHubActionsCoverageObject(coverageObj)) {
-    return generateGitHubActions(coverageObj);
-  }
-
-  if (format === 'json' || format === 'json-summary' || format === 'simplecov') {
-    return JSON.stringify(coverageObj, null, 2);
-  }
-
+function generateXmlContent(coverageObj: AnyCoverageObject, format: string): string {
   const isHeadless = isXmlReportFormat(format);
   const builder = new XMLBuilder(builderOptions);
   let xml = builder.build(coverageObj);
@@ -62,8 +72,7 @@ function generateReportContent(coverageObj: AnyCoverageObject, format: string): 
     xml = xml.replace(/^<\?xml[^>]*>\s*/i, '');
   }
 
-  const finalXml = prependXmlHeader(xml, format).trimEnd();
-  return finalXml;
+  return prependXmlHeader(xml, format).trimEnd();
 }
 
 function generateLcov(coverageObj: LcovCoverageObject): string {
@@ -96,8 +105,4 @@ function prependXmlHeader(xml: string, format: string): string {
 
 export function getExtensionForFormat(format: string): string {
   return HandlerRegistry.getExtension(format);
-}
-
-function isLcovCoverageObject(obj: unknown): obj is LcovCoverageObject {
-  return typeof obj === 'object' && obj !== null && 'files' in obj;
 }

--- a/src/transformers/reportGenerator.ts
+++ b/src/transformers/reportGenerator.ts
@@ -7,6 +7,8 @@ import { HandlerRegistry } from '../handlers/HandlerRegistry.js';
 import { builderOptions, XML_HEADER_CONFIG } from '../utils/constants.js';
 import { XmlReportFormat } from '../utils/types.js';
 import { generateHtml, isHtmlCoverageObject } from './generators/generateHtml.js';
+import { generateMarkdown, isMarkdownCoverageObject } from './generators/generateMarkdown.js';
+import { generateGitHubActions, isGitHubActionsCoverageObject } from './generators/generateGitHubActions.js';
 
 function isXmlReportFormat(format: string): format is XmlReportFormat {
   return format in XML_HEADER_CONFIG;
@@ -16,7 +18,7 @@ export async function generateAndWriteReport(
   outputPath: string,
   coverageObj: AnyCoverageObject,
   format: string,
-  formatAmount: number
+  formatAmount: number,
 ): Promise<string> {
   const content = generateReportContent(coverageObj, format);
   const extension = HandlerRegistry.getExtension(format);
@@ -38,6 +40,14 @@ function generateReportContent(coverageObj: AnyCoverageObject, format: string): 
 
   if (format === 'html' && isHtmlCoverageObject(coverageObj)) {
     return generateHtml(coverageObj);
+  }
+
+  if (format === 'markdown' && isMarkdownCoverageObject(coverageObj)) {
+    return generateMarkdown(coverageObj);
+  }
+
+  if (format === 'github-actions' && isGitHubActionsCoverageObject(coverageObj)) {
+    return generateGitHubActions(coverageObj);
   }
 
   if (format === 'json' || format === 'json-summary' || format === 'simplecov') {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -391,6 +391,53 @@ export type HtmlCoverageObject = {
   files: HtmlFileCoverage[];
 };
 
+// Markdown coverage format types
+export type MarkdownPackageRow = {
+  directory: string;
+  fileCount: number;
+  totalLines: number;
+  coveredLines: number;
+  uncoveredLines: number;
+  lineRate: number;
+};
+
+export type MarkdownFileRow = {
+  filePath: string;
+  totalLines: number;
+  coveredLines: number;
+  uncoveredLines: number;
+  lineRate: number;
+};
+
+export type MarkdownCoverageObject = {
+  summary: {
+    totalLines: number;
+    coveredLines: number;
+    uncoveredLines: number;
+    lineRate: number;
+    fileCount: number;
+  };
+  packages: MarkdownPackageRow[];
+  files: MarkdownFileRow[];
+};
+
+// GitHub Actions workflow command output types
+export type GitHubActionsUncoveredLine = {
+  filePath: string;
+  lineNumber: number;
+};
+
+export type GitHubActionsCoverageObject = {
+  summary: {
+    totalLines: number;
+    coveredLines: number;
+    uncoveredLines: number;
+    lineRate: number;
+    fileCount: number;
+  };
+  uncoveredLines: GitHubActionsUncoveredLine[];
+};
+
 /** Union of every format-specific coverage object the report generator can emit. */
 export type AnyCoverageObject =
   | SonarCoverageObject
@@ -402,7 +449,9 @@ export type AnyCoverageObject =
   | JsonSummaryCoverageObject
   | SimpleCovCoverageObject
   | OpenCoverCoverageObject
-  | HtmlCoverageObject;
+  | HtmlCoverageObject
+  | MarkdownCoverageObject
+  | GitHubActionsCoverageObject;
 
 export type XmlReportFormat = 'cobertura' | 'clover' | 'jacoco' | 'opencover';
 export type XmlHeaderConfig = {

--- a/test/fixtures/baselines/github-actions_baseline.txt
+++ b/test/fixtures/baselines/github-actions_baseline.txt
@@ -1,0 +1,9 @@
+::notice title=Apex Code Coverage::Overall coverage 87.10%25 (54/62 lines, 8 uncovered across 2 files)
+::warning file=force-app/main/default/classes/AccountProfile.cls,line=52,title=Uncovered Apex line::Line 52 is not covered by any Apex test
+::warning file=force-app/main/default/classes/AccountProfile.cls,line=53,title=Uncovered Apex line::Line 53 is not covered by any Apex test
+::warning file=force-app/main/default/classes/AccountProfile.cls,line=59,title=Uncovered Apex line::Line 59 is not covered by any Apex test
+::warning file=force-app/main/default/classes/AccountProfile.cls,line=60,title=Uncovered Apex line::Line 60 is not covered by any Apex test
+::warning file=packaged/triggers/AccountTrigger.trigger,line=52,title=Uncovered Apex line::Line 52 is not covered by any Apex test
+::warning file=packaged/triggers/AccountTrigger.trigger,line=53,title=Uncovered Apex line::Line 53 is not covered by any Apex test
+::warning file=packaged/triggers/AccountTrigger.trigger,line=59,title=Uncovered Apex line::Line 59 is not covered by any Apex test
+::warning file=packaged/triggers/AccountTrigger.trigger,line=60,title=Uncovered Apex line::Line 60 is not covered by any Apex test

--- a/test/fixtures/baselines/markdown_baseline.md
+++ b/test/fixtures/baselines/markdown_baseline.md
@@ -1,0 +1,19 @@
+# Apex Code Coverage Report
+
+**Overall coverage:** 87.10% (54 / 62 lines across 2 files)
+
+## Package directory coverage
+
+| Directory | Files | Lines | Covered | Uncovered | Coverage |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| force-app | 1 | 31 | 27 | 4 | 87.10% |
+| packaged | 1 | 31 | 27 | 4 | 87.10% |
+
+## File coverage
+
+Files are sorted with the lowest coverage first.
+
+| File | Lines | Covered | Uncovered | Coverage |
+| --- | ---: | ---: | ---: | ---: |
+| force-app/main/default/classes/AccountProfile.cls | 31 | 27 | 4 | 87.10% |
+| packaged/triggers/AccountTrigger.trigger | 31 | 27 | 4 | 87.10% |

--- a/test/units/githubActions.test.ts
+++ b/test/units/githubActions.test.ts
@@ -1,0 +1,100 @@
+'use strict';
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { GitHubActionsCoverageHandler } from '../../src/handlers/githubActions.js';
+import { generateAndWriteReport } from '../../src/transformers/reportGenerator.js';
+
+describe('GitHubActionsCoverageHandler unit tests', () => {
+  it('captures uncovered lines and computes the overall summary', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('force-app/main/default/classes/A.cls', 'A', { '1': 1, '2': 0, '3': 0 });
+    handler.processFile('force-app/main/default/classes/B.cls', 'B', { '1': 1, '2': 1 });
+    const result = handler.finalize();
+
+    expect(result.summary.totalLines).toBe(5);
+    expect(result.summary.coveredLines).toBe(3);
+    expect(result.summary.uncoveredLines).toBe(2);
+    expect(result.summary.fileCount).toBe(2);
+    expect(result.uncoveredLines).toEqual([
+      { filePath: 'force-app/main/default/classes/A.cls', lineNumber: 2 },
+      { filePath: 'force-app/main/default/classes/A.cls', lineNumber: 3 },
+    ]);
+  });
+
+  it('sorts annotations by file path then line number', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '5': 0, '1': 0 });
+    handler.processFile('a/First.cls', 'First', { '10': 0, '2': 0 });
+    const result = handler.finalize();
+
+    expect(result.uncoveredLines).toEqual([
+      { filePath: 'a/First.cls', lineNumber: 2 },
+      { filePath: 'a/First.cls', lineNumber: 10 },
+      { filePath: 'z/Last.cls', lineNumber: 1 },
+      { filePath: 'z/Last.cls', lineNumber: 5 },
+    ]);
+  });
+
+  it('handles a file with no uncovered lines without emitting annotations', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Full.cls', 'Full', { '1': 1, '2': 1 });
+    const result = handler.finalize();
+
+    expect(result.summary.uncoveredLines).toBe(0);
+    expect(result.uncoveredLines).toHaveLength(0);
+  });
+
+  it('returns a zero line rate when finalize runs without any processed files', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    const result = handler.finalize();
+
+    expect(result.summary.totalLines).toBe(0);
+    expect(result.summary.coveredLines).toBe(0);
+    expect(result.summary.uncoveredLines).toBe(0);
+    expect(result.summary.lineRate).toBe(0);
+    expect(result.summary.fileCount).toBe(0);
+    expect(result.uncoveredLines).toHaveLength(0);
+  });
+
+  it('renders workflow commands with escaped property values', async () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('force-app/main/default/classes/A.cls', 'A', { '1': 0, '2': 1 });
+    const result = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gha-report-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.txt'), result, 'github-actions', 1);
+      expect(outPath.endsWith('.txt')).toBe(true);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('::notice title=Apex Code Coverage::');
+      expect(content).toContain(
+        '::warning file=force-app/main/default/classes/A.cls,line=1,title=Uncovered Apex line::Line 1 is not covered by any Apex test',
+      );
+      // % must be escaped to %25 in workflow command data
+      expect(content).toContain('50.00%25');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('escapes commas and colons in file paths for workflow command properties', async () => {
+    const handler = new GitHubActionsCoverageHandler();
+    // Salesforce paths shouldn't contain these, but protect against odd inputs
+    handler.processFile('force-app/main/default/classes/A,B:C.cls', 'A,B:C', { '1': 0 });
+    const result = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gha-escape-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.txt'), result, 'github-actions', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('A%2CB%3AC.cls');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+});

--- a/test/units/handlerRegistry.test.ts
+++ b/test/units/handlerRegistry.test.ts
@@ -14,6 +14,8 @@ import '../../src/handlers/jsonSummary.js';
 import '../../src/handlers/simplecov.js';
 import '../../src/handlers/opencover.js';
 import '../../src/handlers/html.js';
+import '../../src/handlers/markdown.js';
+import '../../src/handlers/githubActions.js';
 
 describe('HandlerRegistry unit tests', () => {
   it('should retrieve an existing handler', () => {
@@ -36,7 +38,9 @@ describe('HandlerRegistry unit tests', () => {
     expect(formats).toContain('simplecov');
     expect(formats).toContain('opencover');
     expect(formats).toContain('html');
-    expect(formats.length).toBeGreaterThanOrEqual(10);
+    expect(formats).toContain('markdown');
+    expect(formats).toContain('github-actions');
+    expect(formats.length).toBeGreaterThanOrEqual(12);
   });
 
   it('should return correct file extension for format', () => {
@@ -47,6 +51,8 @@ describe('HandlerRegistry unit tests', () => {
     expect(HandlerRegistry.getExtension('simplecov')).toBe('.json');
     expect(HandlerRegistry.getExtension('opencover')).toBe('.xml');
     expect(HandlerRegistry.getExtension('html')).toBe('.html');
+    expect(HandlerRegistry.getExtension('markdown')).toBe('.md');
+    expect(HandlerRegistry.getExtension('github-actions')).toBe('.txt');
   });
 
   it('should return default extension for unknown format', () => {
@@ -117,5 +123,7 @@ describe('HandlerRegistry unit tests', () => {
     import('../../src/handlers/simplecov.js');
     import('../../src/handlers/opencover.js');
     import('../../src/handlers/html.js');
+    import('../../src/handlers/markdown.js');
+    import('../../src/handlers/githubActions.js');
   });
 });

--- a/test/units/markdown.test.ts
+++ b/test/units/markdown.test.ts
@@ -1,0 +1,116 @@
+'use strict';
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+import { MarkdownCoverageHandler } from '../../src/handlers/markdown.js';
+import { generateAndWriteReport } from '../../src/transformers/reportGenerator.js';
+
+describe('MarkdownCoverageHandler unit tests', () => {
+  it('produces an overall summary, package table, and file table', () => {
+    const handler = new MarkdownCoverageHandler();
+    handler.processFile('force-app/main/default/classes/A.cls', 'A', { '1': 1, '2': 1, '3': 0 });
+    handler.processFile('force-app/main/default/classes/B.cls', 'B', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+
+    expect(result.summary.totalLines).toBe(5);
+    expect(result.summary.coveredLines).toBe(3);
+    expect(result.summary.uncoveredLines).toBe(2);
+    expect(result.summary.fileCount).toBe(2);
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].directory).toBe('force-app');
+    expect(result.packages[0].fileCount).toBe(2);
+  });
+
+  it('sorts files with the lowest coverage first, ties broken by path', () => {
+    const handler = new MarkdownCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Hi.cls', 'Hi', { '1': 1, '2': 1 });
+    handler.processFile('force-app/main/default/classes/Lo.cls', 'Lo', { '1': 0, '2': 0 });
+    handler.processFile('force-app/main/default/classes/Mid.cls', 'Mid', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+
+    expect(result.files.map((f) => f.filePath)).toEqual([
+      'force-app/main/default/classes/Lo.cls',
+      'force-app/main/default/classes/Mid.cls',
+      'force-app/main/default/classes/Hi.cls',
+    ]);
+  });
+
+  it('handles empty input gracefully', () => {
+    const handler = new MarkdownCoverageHandler();
+    const result = handler.finalize();
+
+    expect(result.summary.totalLines).toBe(0);
+    expect(result.summary.lineRate).toBe(0);
+    expect(result.summary.fileCount).toBe(0);
+    expect(result.packages).toHaveLength(0);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it('returns a zero line rate for a package whose files have no lines', () => {
+    const handler = new MarkdownCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Empty.cls', 'Empty', {});
+    const result = handler.finalize();
+
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].directory).toBe('force-app');
+    expect(result.packages[0].totalLines).toBe(0);
+    expect(result.packages[0].coveredLines).toBe(0);
+    expect(result.packages[0].lineRate).toBe(0);
+  });
+
+  it('omits the package and file table sections when there is no data', async () => {
+    const handler = new MarkdownCoverageHandler();
+    const result = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'md-empty-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.md'), result, 'markdown', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('# Apex Code Coverage Report');
+      expect(content).toContain('0.00%');
+      expect(content).not.toContain('## Package directory coverage');
+      expect(content).not.toContain('## File coverage');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('renders a markdown report with the expected sections', async () => {
+    const handler = new MarkdownCoverageHandler();
+    handler.processFile('force-app/main/default/classes/A.cls', 'A', { '1': 1, '2': 1, '3': 0 });
+    const result = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'md-report-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.md'), result, 'markdown', 1);
+      expect(outPath.endsWith('.md')).toBe(true);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('# Apex Code Coverage Report');
+      expect(content).toContain('## Package directory coverage');
+      expect(content).toContain('## File coverage');
+      expect(content).toContain('66.67%');
+      expect(content).toContain('force-app/main/default/classes/A.cls');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('escapes pipe characters in file paths so the table renders correctly', async () => {
+    const handler = new MarkdownCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Weird|Name.cls', 'Weird|Name', { '1': 1 });
+    const result = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'md-pipe-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.md'), result, 'markdown', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('Weird\\|Name.cls');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+});

--- a/test/utils/baselineCompare.ts
+++ b/test/utils/baselineCompare.ts
@@ -17,6 +17,8 @@ import {
   simplecovBaselinePath,
   opencoverBaselinePath,
   htmlBaselinePath,
+  markdownBaselinePath,
+  githubActionsBaselinePath,
 } from './testConstants.js';
 import { normalizeCoverageReport } from './normalizeCoverageReport.js';
 
@@ -32,6 +34,8 @@ export async function compareToBaselines(): Promise<void> {
     simplecov: simplecovBaselinePath,
     opencover: opencoverBaselinePath,
     html: htmlBaselinePath,
+    markdown: markdownBaselinePath,
+    'github-actions': githubActionsBaselinePath,
   } as const;
 
   const normalizationRequired = new Set([
@@ -61,7 +65,7 @@ export async function compareToBaselines(): Promise<void> {
         strictEqual(
           normalizeCoverageReport(outputContent, isJson),
           normalizeCoverageReport(baselineContent, isJson),
-          `Mismatch between ${outputPath} and ${baselineMap[formatKey]}`
+          `Mismatch between ${outputPath} and ${baselineMap[formatKey]}`,
         );
       } else {
         strictEqual(outputContent, baselineContent, `Mismatch between ${outputPath} and ${baselineMap[formatKey]}`);

--- a/test/utils/testConstants.ts
+++ b/test/utils/testConstants.ts
@@ -17,6 +17,8 @@ export const jsonSummaryBaselinePath = resolve(fixturesDir, 'baselines/json-summ
 export const simplecovBaselinePath = resolve(fixturesDir, 'baselines/simplecov_baseline.json');
 export const opencoverBaselinePath = resolve(fixturesDir, 'baselines/opencover_baseline.xml');
 export const htmlBaselinePath = resolve(fixturesDir, 'baselines/html_baseline.html');
+export const markdownBaselinePath = resolve(fixturesDir, 'baselines/markdown_baseline.md');
+export const githubActionsBaselinePath = resolve(fixturesDir, 'baselines/github-actions_baseline.txt');
 export const defaultPath = resolve('coverage.xml');
 export const sfdxConfigFile = resolve('sfdx-project.json');
 


### PR DESCRIPTION
Markdown summaries drop into PR/MR comments and $GITHUB_STEP_SUMMARY without needing a third-party summary action. The github-actions format emits ::warning workflow commands per uncovered Apex line, pairing with sf-cat's quality annotations so coverage gaps and quality findings render inline on the same PR diff.