### PR TITLE
refactor: replace async package with in-house mapLimit utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@oclif/core": "4.8.3",
         "@salesforce/core": "8.26.3",
         "@salesforce/sf-plugins-core": "12.2.6",
-        "async": "3.2.6",
         "fast-xml-builder": "1.1.7"
       },
       "devDependencies": {
@@ -22,7 +21,6 @@
         "@salesforce/cli-plugins-testkit": "5.3.39",
         "@salesforce/dev-config": "4.3.3",
         "@salesforce/prettier-config": "0.0.4",
-        "@types/async": "3.2.24",
         "@types/node": "20.19.39",
         "@vitest/coverage-v8": "4.1.5",
         "eslint-config-salesforce-typescript": "4.0.1",
@@ -4181,13 +4179,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/async": {
-      "version": "3.2.24",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.24.tgz",
-      "integrity": "sha512-8iHVLHsCCOBKjCF2KwFe0p9Z3rfM9mL+sSP8btyR5vTjJRAqpBYD28/ZLgXPf0pjG1VxOvtCV/BgXkQbpSe8Hw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@oclif/core": "4.8.3",
     "@salesforce/core": "8.26.3",
     "@salesforce/sf-plugins-core": "12.2.6",
-    "async": "3.2.6",
     "fast-xml-builder": "1.1.7"
   },
   "devDependencies": {
@@ -16,7 +15,6 @@
     "@salesforce/cli-plugins-testkit": "5.3.39",
     "@salesforce/dev-config": "4.3.3",
     "@salesforce/prettier-config": "0.0.4",
-    "@types/async": "3.2.24",
     "@types/node": "20.19.39",
     "@vitest/coverage-v8": "4.1.5",
     "eslint-config-salesforce-typescript": "4.0.1",

--- a/src/transformers/coverageTransformer.ts
+++ b/src/transformers/coverageTransformer.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { mapLimit } from 'async';
 
 import { getCoverageHandler } from '../handlers/getHandler.js';
 import { DeployCoverageData, TestCoverageData, CoverageProcessingContext } from '../utils/types.js';
@@ -11,6 +10,7 @@ import { buildFilePathCache } from '../utils/buildFilePathCache.js';
 import { setCoveredLines, type SetCoveredLinesResult } from '../utils/setCoveredLines.js';
 import { getConcurrencyThreshold } from '../utils/getConcurrencyThreshold.js';
 import { checkCoverageDataType } from '../utils/setCoverageDataType.js';
+import { mapLimit } from '../utils/mapLimit.js';
 import { generateAndWriteReport } from './reportGenerator.js';
 
 type CoverageInput = DeployCoverageData | TestCoverageData[];
@@ -19,7 +19,7 @@ export async function transformCoverageReport(
   jsonFilePath: string,
   outputReportPath: string,
   formats: string[],
-  ignoreDirs: string[]
+  ignoreDirs: string[],
 ): Promise<{ finalPaths: string[]; warnings: string[] }> {
   const warnings: string[] = [];
   const finalPaths: string[] = [];
@@ -53,7 +53,7 @@ export async function transformCoverageReport(
     filesProcessed = await processTestCoverage(parsedData as TestCoverageData[], context);
   } else {
     throw new Error(
-      'The provided JSON does not match a known coverage data format from the Salesforce deploy or test command.'
+      'The provided JSON does not match a known coverage data format from the Salesforce deploy or test command.',
     );
   }
 
@@ -71,7 +71,7 @@ export async function transformCoverageReport(
 }
 
 function hasSourceContent(
-  result: SetCoveredLinesResult
+  result: SetCoveredLinesResult,
 ): result is { updatedLines: Record<string, number>; sourceContent: string } {
   return typeof result === 'object' && result !== null && 'sourceContent' in result;
 }
@@ -127,7 +127,6 @@ async function processDeployCoverage(data: DeployCoverageData, context: Coverage
 
 async function processTestCoverage(data: TestCoverageData[], context: CoverageProcessingContext): Promise<number> {
   let processed = 0;
-  // eslint-disable-next-line @typescript-eslint/require-await
   await mapLimit(data, context.concurrencyLimit, async (entry: TestCoverageData) => {
     const formattedName = entry.name.replace(/no-map[\\/]+/, '');
     const path = findFilePath(formattedName, context.filePathCache);

--- a/src/utils/mapLimit.ts
+++ b/src/utils/mapLimit.ts
@@ -9,29 +9,15 @@
  * @param iteratee  - Async function to run for each item
  */
 export async function mapLimit<T>(items: T[], limit: number, iteratee: (item: T) => Promise<void>): Promise<void> {
-  const iterator = items[Symbol.iterator]();
-  let active = 0;
-  let done = false;
-
-  return new Promise((resolve, reject) => {
-    function next(): void {
-      while (active < limit && !done) {
-        const { value, done: iterDone } = iterator.next();
-        if (iterDone) {
-          done = true;
-          if (active === 0) resolve();
-          return;
-        }
-        active++;
-        iteratee(value)
-          .then(() => {
-            active--;
-            next();
-            if (done && active === 0) resolve();
-          })
-          .catch(reject);
-      }
+  const concurrency = Math.max(1, limit);
+  const queue = items.slice();
+  const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
+    while (queue.length > 0) {
+      const item = queue.shift()!;
+      // eslint-disable-next-line no-await-in-loop
+      await iteratee(item);
     }
-    next();
   });
+
+  await Promise.all(workers);
 }

--- a/src/utils/mapLimit.ts
+++ b/src/utils/mapLimit.ts
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Process an array concurrently with a maximum concurrency limit.
+ * Drop-in replacement for the `async` package's `mapLimit`.
+ *
+ * @param items     - Items to process
+ * @param limit     - Max number of concurrent tasks
+ * @param iteratee  - Async function to run for each item
+ */
+export async function mapLimit<T>(items: T[], limit: number, iteratee: (item: T) => Promise<void>): Promise<void> {
+  const iterator = items[Symbol.iterator]();
+  let active = 0;
+  let done = false;
+
+  return new Promise((resolve, reject) => {
+    function next(): void {
+      while (active < limit && !done) {
+        const { value, done: iterDone } = iterator.next();
+        if (iterDone) {
+          done = true;
+          if (active === 0) resolve();
+          return;
+        }
+        active++;
+        iteratee(value)
+          .then(() => {
+            active--;
+            next();
+            if (done && active === 0) resolve();
+          })
+          .catch(reject);
+      }
+    }
+    next();
+  });
+}

--- a/test/units/mapLimit.test.ts
+++ b/test/units/mapLimit.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { mapLimit } from '../../src/utils/mapLimit.js';
+
+describe('mapLimit', () => {
+  it('processes all items with the requested concurrency', async () => {
+    const items = [1, 2, 3, 4];
+    const concurrency = 2;
+    const activeStates: number[] = [];
+    let active = 0;
+    const processed: number[] = [];
+
+    await mapLimit(items, concurrency, async (item) => {
+      activeStates.push(++active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      processed.push(item);
+      active--;
+    });
+
+    expect(Math.max(...activeStates)).toBeLessThanOrEqual(concurrency);
+    expect(processed.sort((a, b) => a - b)).toEqual(items);
+  });
+
+  it('resolves immediately when there are no items', async () => {
+    await expect(mapLimit([], 2, async () => undefined)).resolves.toBeUndefined();
+  });
+
+  it('rejects when an iteratee throws an error', async () => {
+    await expect(
+      mapLimit([1, 2, 3], 2, async (item) => {
+        if (item === 2) {
+          throw new Error('boom');
+        }
+      }),
+    ).rejects.toThrow('boom');
+  });
+
+  it('treats a non-positive limit as a concurrency of 1', async () => {
+    const values: number[] = [];
+    await mapLimit([10, 20, 30], 0, async (item) => {
+      values.push(item);
+    });
+    expect(values).toEqual([10, 20, 30]);
+  });
+});


### PR DESCRIPTION
## Summary
Removes the `async` package dependency and replaces the single used function,
`mapLimit`, with a small in-house utility.

## Changes
- Add `src/utils/mapLimit.ts` — a pull-based concurrent iterator with identical
  call signature to `async.mapLimit`
- Update `coverageTransformer.ts` to import from the new utility
- Remove `async` (and `@types/async`) from dependencies

## Why
`async` is a large, general-purpose library. Only `mapLimit` was used,
making it straightforward to own the implementation directly and eliminate
the external dependency.

## Implementation note
The utility uses a pull-based iterator rather than chunking the array into
batches of `limit`. This keeps exactly `limit` tasks in-flight at all times —
a slot opens the moment any task finishes — which is more efficient when tasks
have variable I/O latency, as `setCoveredLines` and `readSourceFile` do here.