### PR TITLE
fix: warn and deduplicate on same-named Apex files across packages

### DIFF
--- a/src/transformers/coverageTransformer.ts
+++ b/src/transformers/coverageTransformer.ts
@@ -36,7 +36,8 @@ export async function transformCoverageReport(
   const concurrencyLimit = getConcurrencyThreshold();
 
   // Build file path cache upfront to avoid O(n*m) directory traversals
-  const filePathCache = await buildFilePathCache(packageDirectories, repoRoot);
+  const { cache: filePathCache, warnings: cacheWarnings } = await buildFilePathCache(packageDirectories, repoRoot);
+  warnings.push(...cacheWarnings);
 
   const context: CoverageProcessingContext = {
     handlers,

--- a/src/utils/buildFilePathCache.ts
+++ b/src/utils/buildFilePathCache.ts
@@ -9,27 +9,27 @@ export type FilePathCacheResult = {
   warnings: string[];
 };
 
+type ScanContext = {
+  repoRoot: string;
+  extensions: string[];
+  cache: Map<string, string>;
+  warnings: string[];
+};
+
 export async function buildFilePathCache(packageDirectories: string[], repoRoot: string): Promise<FilePathCacheResult> {
-  const cache = new Map<string, string>();
-  const warnings: string[] = [];
-  const extensions = ['cls', 'trigger'];
+  const ctx: ScanContext = {
+    repoRoot,
+    extensions: ['cls', 'trigger'],
+    cache: new Map<string, string>(),
+    warnings: [],
+  };
 
-  await Promise.all(
-    packageDirectories.map(async (directory) => {
-      await scanDirectory(directory, repoRoot, extensions, cache, warnings);
-    }),
-  );
+  await Promise.all(packageDirectories.map(async (directory) => scanDirectory(directory, ctx)));
 
-  return { cache, warnings };
+  return { cache: ctx.cache, warnings: ctx.warnings };
 }
 
-async function scanDirectory(
-  directory: string,
-  repoRoot: string,
-  extensions: string[],
-  cache: Map<string, string>,
-  warnings: string[],
-): Promise<void> {
+async function scanDirectory(directory: string, ctx: ScanContext): Promise<void> {
   let entries: string[];
 
   try {
@@ -54,38 +54,31 @@ async function scanDirectory(
     }
 
     if (stats.isDirectory()) {
-      subdirPromises.push(scanDirectory(fullPath, repoRoot, extensions, cache, warnings));
+      subdirPromises.push(scanDirectory(fullPath, ctx));
     } else {
-      processApexFile(entry, fullPath, repoRoot, extensions, cache, warnings);
+      processApexFile(entry, fullPath, ctx);
     }
   }
 
   await Promise.all(subdirPromises);
 }
 
-function processApexFile(
-  entry: string,
-  fullPath: string,
-  repoRoot: string,
-  extensions: string[],
-  cache: Map<string, string>,
-  warnings: string[],
-): void {
+function processApexFile(entry: string, fullPath: string, ctx: ScanContext): void {
   const ext = entry.split('.').pop();
-  if (!ext || !extensions.includes(ext)) return;
+  if (!ext || !ctx.extensions.includes(ext)) return;
 
-  const relativePath = normalizePathToUnix(relative(repoRoot, fullPath));
+  const relativePath = normalizePathToUnix(relative(ctx.repoRoot, fullPath));
   const nameWithoutExt = entry.substring(0, entry.lastIndexOf('.'));
 
-  if (cache.has(entry)) {
-    warnings.push(
-      `Duplicate Apex file "${entry}" found in multiple package directories. Using "${cache.get(entry)!}"; ignoring "${relativePath}".`,
+  if (ctx.cache.has(entry)) {
+    ctx.warnings.push(
+      `Duplicate Apex file "${entry}" found in multiple package directories. Using "${ctx.cache.get(entry)!}"; ignoring "${relativePath}".`,
     );
     return;
   }
 
-  cache.set(entry, relativePath);
-  if (!cache.has(nameWithoutExt)) {
-    cache.set(nameWithoutExt, relativePath);
+  ctx.cache.set(entry, relativePath);
+  if (!ctx.cache.has(nameWithoutExt)) {
+    ctx.cache.set(nameWithoutExt, relativePath);
   }
 }

--- a/src/utils/buildFilePathCache.ts
+++ b/src/utils/buildFilePathCache.ts
@@ -54,29 +54,38 @@ async function scanDirectory(
     }
 
     if (stats.isDirectory()) {
-      // Queue subdirectory scanning
       subdirPromises.push(scanDirectory(fullPath, repoRoot, extensions, cache, warnings));
     } else {
-      // Check if this is an Apex file
-      const ext = entry.split('.').pop();
-      if (ext && extensions.includes(ext)) {
-        const relativePath = normalizePathToUnix(relative(repoRoot, fullPath));
-        const nameWithoutExt = entry.substring(0, entry.lastIndexOf('.'));
-
-        if (cache.has(entry)) {
-          warnings.push(
-            `Duplicate Apex file "${entry}" found in multiple package directories. Using "${cache.get(entry)!}"; ignoring "${relativePath}".`,
-          );
-        } else {
-          cache.set(entry, relativePath);
-          if (!cache.has(nameWithoutExt)) {
-            cache.set(nameWithoutExt, relativePath);
-          }
-        }
-      }
+      processApexFile(entry, fullPath, repoRoot, extensions, cache, warnings);
     }
   }
 
-  // Process all subdirectories in parallel
   await Promise.all(subdirPromises);
+}
+
+function processApexFile(
+  entry: string,
+  fullPath: string,
+  repoRoot: string,
+  extensions: string[],
+  cache: Map<string, string>,
+  warnings: string[],
+): void {
+  const ext = entry.split('.').pop();
+  if (!ext || !extensions.includes(ext)) return;
+
+  const relativePath = normalizePathToUnix(relative(repoRoot, fullPath));
+  const nameWithoutExt = entry.substring(0, entry.lastIndexOf('.'));
+
+  if (cache.has(entry)) {
+    warnings.push(
+      `Duplicate Apex file "${entry}" found in multiple package directories. Using "${cache.get(entry)!}"; ignoring "${relativePath}".`,
+    );
+    return;
+  }
+
+  cache.set(entry, relativePath);
+  if (!cache.has(nameWithoutExt)) {
+    cache.set(nameWithoutExt, relativePath);
+  }
 }

--- a/src/utils/buildFilePathCache.ts
+++ b/src/utils/buildFilePathCache.ts
@@ -4,32 +4,31 @@ import { readdir, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import { normalizePathToUnix } from './normalizePathToUnix.js';
 
-/**
- * Build a cache mapping filenames to their full paths.
- * This prevents recursive directory searches for every file in the coverage report.
- *
- * @param packageDirectories - Array of package directory paths to scan
- * @param repoRoot - Repository root path
- * @returns Map of filename (without path) to full relative path
- */
-export async function buildFilePathCache(packageDirectories: string[], repoRoot: string): Promise<Map<string, string>> {
+export type FilePathCacheResult = {
+  cache: Map<string, string>;
+  warnings: string[];
+};
+
+export async function buildFilePathCache(packageDirectories: string[], repoRoot: string): Promise<FilePathCacheResult> {
   const cache = new Map<string, string>();
+  const warnings: string[] = [];
   const extensions = ['cls', 'trigger'];
 
   await Promise.all(
     packageDirectories.map(async (directory) => {
-      await scanDirectory(directory, repoRoot, extensions, cache);
-    })
+      await scanDirectory(directory, repoRoot, extensions, cache, warnings);
+    }),
   );
 
-  return cache;
+  return { cache, warnings };
 }
 
 async function scanDirectory(
   directory: string,
   repoRoot: string,
   extensions: string[],
-  cache: Map<string, string>
+  cache: Map<string, string>,
+  warnings: string[],
 ): Promise<void> {
   let entries: string[];
 
@@ -56,18 +55,23 @@ async function scanDirectory(
 
     if (stats.isDirectory()) {
       // Queue subdirectory scanning
-      subdirPromises.push(scanDirectory(fullPath, repoRoot, extensions, cache));
+      subdirPromises.push(scanDirectory(fullPath, repoRoot, extensions, cache, warnings));
     } else {
       // Check if this is an Apex file
       const ext = entry.split('.').pop();
       if (ext && extensions.includes(ext)) {
         const relativePath = normalizePathToUnix(relative(repoRoot, fullPath));
-        // Store with the full filename as key (e.g., "AccountHandler.cls")
-        cache.set(entry, relativePath);
-        // Also store without extension for lookups (e.g., "AccountHandler")
         const nameWithoutExt = entry.substring(0, entry.lastIndexOf('.'));
-        if (!cache.has(nameWithoutExt)) {
-          cache.set(nameWithoutExt, relativePath);
+
+        if (cache.has(entry)) {
+          warnings.push(
+            `Duplicate Apex file "${entry}" found in multiple package directories. Using "${cache.get(entry)!}"; ignoring "${relativePath}".`,
+          );
+        } else {
+          cache.set(entry, relativePath);
+          if (!cache.has(nameWithoutExt)) {
+            cache.set(nameWithoutExt, relativePath);
+          }
         }
       }
     }

--- a/test/units/buildFilePathCache.statFailure.test.ts
+++ b/test/units/buildFilePathCache.statFailure.test.ts
@@ -43,7 +43,7 @@ describe('buildFilePathCache stat failure', () => {
       return actualFs.stat(path);
     });
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('Good.cls')).toBe(true);
     expect(cache.has('Bad.cls')).toBe(false);

--- a/test/units/buildFilePathCache.test.ts
+++ b/test/units/buildFilePathCache.test.ts
@@ -27,7 +27,7 @@ describe('buildFilePathCache', () => {
     await writeFile(join(packageDir1, 'AccountHandler.cls'), 'public class AccountHandler {}');
     await writeFile(join(packageDir1, 'ContactHandler.cls'), 'public class ContactHandler {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('AccountHandler.cls')).toBe(true);
     expect(cache.has('AccountHandler')).toBe(true);
@@ -40,7 +40,7 @@ describe('buildFilePathCache', () => {
     // Create test files
     await writeFile(join(packageDir2, 'AccountTrigger.trigger'), 'trigger AccountTrigger on Account {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'packaged')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'packaged')], repoRoot);
 
     expect(cache.has('AccountTrigger.trigger')).toBe(true);
     expect(cache.has('AccountTrigger')).toBe(true);
@@ -51,7 +51,7 @@ describe('buildFilePathCache', () => {
     await writeFile(join(packageDir1, 'Class1.cls'), 'public class Class1 {}');
     await writeFile(join(packageDir2, 'Trigger1.trigger'), 'trigger Trigger1 on Account {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app'), join(testDir, 'packaged')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app'), join(testDir, 'packaged')], repoRoot);
 
     expect(cache.has('Class1.cls')).toBe(true);
     expect(cache.has('Trigger1.trigger')).toBe(true);
@@ -61,7 +61,7 @@ describe('buildFilePathCache', () => {
     const nonExistentDir = join(testDir, 'non-existent');
 
     // Should not throw error
-    const cache = await buildFilePathCache([nonExistentDir], repoRoot);
+    const { cache } = await buildFilePathCache([nonExistentDir], repoRoot);
 
     expect(cache.size).toBe(0);
   });
@@ -71,7 +71,7 @@ describe('buildFilePathCache', () => {
     await mkdir(nestedDir, { recursive: true });
     await writeFile(join(nestedDir, 'DeepClass.cls'), 'public class DeepClass {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('DeepClass.cls')).toBe(true);
     expect(cache.has('DeepClass')).toBe(true);
@@ -82,7 +82,7 @@ describe('buildFilePathCache', () => {
     await writeFile(join(packageDir1, 'README.md'), '# Readme');
     await writeFile(join(packageDir1, 'config.xml'), '<xml/>');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('AccountHandler.cls')).toBe(true);
     expect(cache.has('README.md')).toBe(false);
@@ -94,7 +94,7 @@ describe('buildFilePathCache', () => {
     // 'AccountHandler.cls' and 'AccountHandler', and won't be overwritten
     await writeFile(join(packageDir1, 'AccountHandler.cls'), 'public class AccountHandler {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('AccountHandler')).toBe(true);
     expect(cache.has('AccountHandler.cls')).toBe(true);
@@ -123,7 +123,7 @@ describe('buildFilePathCache', () => {
     }
 
     // Build cache - should not crash even if a file becomes inaccessible
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     expect(cache.has('ValidClass.cls')).toBe(true);
     // BrokenLink should not be in cache since stat failed
@@ -133,12 +133,32 @@ describe('buildFilePathCache', () => {
   it('should normalize paths to Unix format', async () => {
     await writeFile(join(packageDir1, 'TestClass.cls'), 'public class TestClass {}');
 
-    const cache = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
+    const { cache } = await buildFilePathCache([join(testDir, 'force-app')], repoRoot);
 
     const path = cache.get('TestClass.cls');
     expect(path).toBeDefined();
     // Unix paths use forward slashes
     expect(path).not.toContain('\\');
     expect(path).toContain('/');
+  });
+
+  it('should warn and keep first entry when two packages have the same filename', async () => {
+    const pkg2Dir = join(testDir, 'package2', 'main', 'default', 'classes');
+    await mkdir(pkg2Dir, { recursive: true });
+    await writeFile(join(packageDir1, 'SharedClass.cls'), 'public class SharedClass {}');
+    await writeFile(join(pkg2Dir, 'SharedClass.cls'), 'public class SharedClass {}');
+
+    const { cache, warnings } = await buildFilePathCache(
+      [join(testDir, 'force-app'), join(testDir, 'package2')],
+      repoRoot,
+    );
+
+    expect(cache.has('SharedClass.cls')).toBe(true);
+    expect(cache.has('SharedClass')).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('SharedClass.cls');
+    expect(warnings[0]).toContain('ignoring');
+    // Both cache keys point to the first-found file
+    expect(cache.get('SharedClass.cls')).toBe(cache.get('SharedClass'));
   });
 });

--- a/test/units/buildFilePathCache.test.ts
+++ b/test/units/buildFilePathCache.test.ts
@@ -161,4 +161,22 @@ describe('buildFilePathCache', () => {
     // Both cache keys point to the first-found file
     expect(cache.get('SharedClass.cls')).toBe(cache.get('SharedClass'));
   });
+
+  it('should not overwrite no-extension key when a cls and trigger share the same base name', async () => {
+    await writeFile(join(packageDir1, 'Account.cls'), 'public class Account {}');
+    await writeFile(join(packageDir2, 'Account.trigger'), 'trigger Account on Account (before insert) {}');
+
+    const { cache, warnings } = await buildFilePathCache(
+      [join(testDir, 'force-app'), join(testDir, 'packaged')],
+      repoRoot,
+    );
+
+    expect(cache.has('Account.cls')).toBe(true);
+    expect(cache.has('Account.trigger')).toBe(true);
+    expect(cache.has('Account')).toBe(true);
+    // No-extension key set by whichever file was cached first; no collision warning
+    expect(warnings).toHaveLength(0);
+    const noExtPath = cache.get('Account')!;
+    expect([cache.get('Account.cls'), cache.get('Account.trigger')]).toContain(noExtPath);
+  });
 });


### PR DESCRIPTION
## Summary

- `buildFilePathCache` previously had inconsistent deduplication: the full-filename key (`AccountHandler.cls`) was always overwritten by the last package directory scanned, while the no-extension key (`AccountHandler`) used a first-wins guard. Two packages with identically-named classes/triggers would silently produce wrong coverage data.
- Both keys are now first-wins (consistent).
- When a collision is detected, a warning is pushed to the returned `warnings` array and surfaces to the user through the existing warnings pipeline.
- Return type changed from `Map<string, string>` to `{ cache: Map<string, string>; warnings: string[] }`.

## Test plan

- [ ] Existing 103 unit tests pass (`npm run test:only`)
- [ ] New test: two packages with `SharedClass.cls` — cache retains first-found path, warning emitted containing filename and `"ignoring"`
- [ ] `buildFilePathCache.statFailure.test.ts` updated to destructure new return type

🤖 Generated with [Claude Code](https://claude.com/claude-code)