### PR TITLE
fix: guard against NaN line-rate in Cobertura when no lines tracked

### DIFF
--- a/src/handlers/cobertura.ts
+++ b/src/handlers/cobertura.ts
@@ -86,12 +86,15 @@ export class CoberturaCoverageHandler extends BaseHandler {
       const totalLines = pkg.classes.class.reduce((sum, cls) => sum + cls['@line-rate'] * cls.lines.line.length, 0);
       const totalClasses = pkg.classes.class.reduce((sum, cls) => sum + cls.lines.line.length, 0);
 
-      pkg['@line-rate'] = parseFloat((totalLines / totalClasses).toFixed(4));
+      pkg['@line-rate'] = totalClasses > 0 ? parseFloat((totalLines / totalClasses).toFixed(4)) : 0;
     }
 
-    this.coverageObj.coverage['@line-rate'] = parseFloat(
-      (this.coverageObj.coverage['@lines-covered'] / this.coverageObj.coverage['@lines-valid']).toFixed(4)
-    );
+    this.coverageObj.coverage['@line-rate'] =
+      this.coverageObj.coverage['@lines-valid'] > 0
+        ? parseFloat(
+            (this.coverageObj.coverage['@lines-covered'] / this.coverageObj.coverage['@lines-valid']).toFixed(4),
+          )
+        : 0;
 
     this.coverageObj.coverage.packages.package.sort((a, b) => a['@name'].localeCompare(b['@name']));
     for (const pkg of this.coverageObj.coverage.packages.package) {

--- a/test/units/coberturaHandler.test.ts
+++ b/test/units/coberturaHandler.test.ts
@@ -5,10 +5,11 @@ import { describe, it, expect } from 'vitest';
 import { CoberturaCoverageHandler } from '../../src/handlers/cobertura.js';
 
 describe('CoberturaCoverageHandler branch coverage', () => {
-  it('processes a file with zero total lines without updating the class line-rate', () => {
+  it('processes a file with zero total lines without producing NaN line-rates', () => {
     const handler = new CoberturaCoverageHandler();
 
     // Empty lines triggers the `totalLines > 0` false branch in processFile
+    // and the zero-guard branches in finalize (package and global line-rate)
     handler.processFile('pkg/empty.cls', 'EmptyFile', {});
     const result = handler.finalize();
 
@@ -16,9 +17,11 @@ describe('CoberturaCoverageHandler branch coverage', () => {
     expect(pkg['@name']).toBe('pkg');
     const cls = pkg.classes.class[0];
     expect(cls['@filename']).toBe('pkg/empty.cls');
-    // When totalLines is 0 the class '@line-rate' stays at its default (0)
     expect(cls['@line-rate']).toBe(0);
     expect(cls.lines.line).toEqual([]);
+    // Package and global rates must be 0, not NaN, when no lines are tracked
+    expect(pkg['@line-rate']).toBe(0);
+    expect(result.coverage['@line-rate']).toBe(0);
   });
 
   it('sorts packages and classes within each package by name', () => {


### PR DESCRIPTION
## Summary

- `finalize()` in `CoberturaCoverageHandler` computed package and global `@line-rate` via division without guarding for a zero denominator
- A file with no tracked lines (empty lines object) produced `NaN` in both values, silently breaking every downstream tool that reads `line-rate` from the Cobertura XML (Codecov, Azure DevOps, Jenkins, GitLab, etc.)
- Both division sites now return `0` when the denominator is zero

## Test plan

- [ ] Existing empty-file test extended to assert `pkg['@line-rate']` and `result.coverage['@line-rate']` are `0`, not `NaN`
- [ ] All 104 unit tests pass (`npm run test:only`)
- [ ] Branch coverage 100% (192/192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)