### PR TITLE
refactor: remove findFilePath dead code path and make cache required

### DIFF
--- a/src/utils/findFilePath.ts
+++ b/src/utils/findFilePath.ts
@@ -1,40 +1,14 @@
 'use strict';
 
-/**
- * Find file path using a pre-built cache (fast) or fallback to the old method.
- *
- * @param fileName - Name of the file to find
- * @param filePathCache - Optional pre-built cache of filename -> path mappings
- * @returns Normalized Unix-style relative path or undefined if not found
- */
-export function findFilePath(fileName: string, filePathCache?: Map<string, string>): string | undefined {
-  if (filePathCache) {
-    return findFilePathFromCache(fileName, filePathCache);
-  }
+export function findFilePath(fileName: string, filePathCache: Map<string, string>): string | undefined {
+  const exactMatch = filePathCache.get(fileName);
+  if (exactMatch) return exactMatch;
 
-  // Fallback to old behavior should never happen in practice,
-  // but keeping for backwards compatibility
-  return undefined;
-}
+  const clsMatch = filePathCache.get(`${fileName}.cls`);
+  if (clsMatch) return clsMatch;
 
-function findFilePathFromCache(fileName: string, cache: Map<string, string>): string | undefined {
-  // Try exact match first
-  const exactMatch = cache.get(fileName);
-  if (exactMatch) {
-    return exactMatch;
-  }
-
-  // Try with .cls extension
-  const clsMatch = cache.get(`${fileName}.cls`);
-  if (clsMatch) {
-    return clsMatch;
-  }
-
-  // Try with .trigger extension
-  const triggerMatch = cache.get(`${fileName}.trigger`);
-  if (triggerMatch) {
-    return triggerMatch;
-  }
+  const triggerMatch = filePathCache.get(`${fileName}.trigger`);
+  if (triggerMatch) return triggerMatch;
 
   return undefined;
 }

--- a/test/units/findFilePath.test.ts
+++ b/test/units/findFilePath.test.ts
@@ -95,18 +95,6 @@ describe('findFilePath', () => {
     });
   });
 
-  describe('without cache', () => {
-    it('should return undefined when cache is not provided', () => {
-      const result = findFilePath('AccountHandler');
-      expect(result).toBeUndefined();
-    });
-
-    it('should return undefined for any filename when cache is undefined', () => {
-      const result = findFilePath('TestClass', undefined);
-      expect(result).toBeUndefined();
-    });
-  });
-
   describe('edge cases', () => {
     it('should handle empty cache', () => {
       const cache = new Map<string, string>();


### PR DESCRIPTION
## Summary

- The no-cache fallback in `findFilePath` always returned `undefined` and was unreachable — both callers in `coverageTransformer.ts` always supply a `filePathCache`
- Removed the optional wrapper function, inlined the lookup logic as the exported function, and made `filePathCache` a required parameter
- Removed the two unit tests that covered the dead path (`without cache` describe block)
- `findFilePath.ts` shrinks from 41 lines to 14

## Test plan

- [ ] 110 unit tests pass (`npm run test:only`) — 100% coverage (203/203 branches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)