### PR TITLE
test: add targeted unit tests to improve mutation score

### DIFF
--- a/test/commands/acc-transformer/transform.test.ts
+++ b/test/commands/acc-transformer/transform.test.ts
@@ -68,6 +68,10 @@ describe('acc-transformer transform unit tests', () => {
       ['packaged', 'force-app', samplesPackagePath],
     );
     expect(result.warnings).toContain('The file name AccountTrigger was not found in any package directory.');
+    // All files are ignored so processed=0 → emits the empty-report warning
+    expect(result.warnings).toContain(
+      'None of the files listed in the coverage JSON were processed. The coverage report will be empty.',
+    );
   });
   it('ignore a package directory and produce a warning on the test command report.', async () => {
     const result = await transformCoverageReport(
@@ -117,5 +121,34 @@ describe('acc-transformer transform unit tests', () => {
     } finally {
       shouldSimulateReadFailureForAccountTrigger = false;
     }
+  });
+  it('does NOT throw when lineRate=0 and minCoverage=0 (strict < not <=)', async () => {
+    // When all dirs ignored, no files processed → lineRate=0.
+    // With minCoverage=0: "0 < 0" is false → no throw. If mutated to "<=", "0 <= 0" is true → throws.
+    await expect(
+      transformCoverageReport(
+        deployCoverage,
+        'coverage.xml',
+        ['sonar'],
+        ['packaged', 'force-app', samplesPackagePath],
+        {
+          minCoverage: 0,
+        },
+      ),
+    ).resolves.toBeDefined();
+  });
+  it('produces one finalPath entry per format', async () => {
+    const result = await transformCoverageReport(
+      deployCoverage,
+      'coverage.xml',
+      ['sonar', 'cobertura'],
+      [samplesPackagePath],
+    );
+    expect(result.finalPaths).toHaveLength(2);
+  });
+  it('returns lineRate=0 and includes path in finalPaths when JSON cannot be read', async () => {
+    const result = await transformCoverageReport('nonexistent-file.json', 'coverage.xml', ['sonar'], []);
+    expect(result.lineRate).toBe(0);
+    expect(result.finalPaths).toContain('coverage.xml');
   });
 });

--- a/test/units/cloverHandler.test.ts
+++ b/test/units/cloverHandler.test.ts
@@ -1,0 +1,105 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { CloverCoverageHandler } from '../../src/handlers/clover.js';
+
+describe('CloverCoverageHandler unit tests', () => {
+  it('sets @count=1 for covered lines and @count=0 for uncovered', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const lines = result.coverage.project.file[0].line;
+    const line1 = lines.find((l) => l['@num'] === 1);
+    const line2 = lines.find((l) => l['@num'] === 2);
+    expect(line1?.['@count']).toBe(1);
+    expect(line2?.['@count']).toBe(0);
+  });
+
+  it('sets @type to "stmt" for every line', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '1': 1, '2': 0, '3': 1 });
+    const result = handler.finalize();
+    const lines = result.coverage.project.file[0].line;
+    expect(lines.every((l) => l['@type'] === 'stmt')).toBe(true);
+  });
+
+  it('records correct @num for each line', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '5': 1, '10': 0 });
+    const result = handler.finalize();
+    const nums = result.coverage.project.file[0].line.map((l) => l['@num']);
+    expect(nums).toContain(5);
+    expect(nums).toContain(10);
+  });
+
+  it('accumulates @statements, @coveredstatements in project metrics', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0, '3': 1 });
+    handler.processFile('b.cls', 'B', { '1': 1, '2': 1 });
+    const result = handler.finalize();
+    const m = result.coverage.project.metrics;
+    expect(m['@statements']).toBe(5);
+    expect(m['@coveredstatements']).toBe(4);
+  });
+
+  it('accumulates @elements, @coveredelements in project metrics', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const m = result.coverage.project.metrics;
+    expect(m['@elements']).toBe(2);
+    expect(m['@coveredelements']).toBe(1);
+  });
+
+  it('increments @files and @classes per processed file', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1 });
+    handler.processFile('b.cls', 'B', { '1': 1 });
+    const result = handler.finalize();
+    const m = result.coverage.project.metrics;
+    expect(m['@files']).toBe(2);
+    expect(m['@classes']).toBe(2);
+  });
+
+  it('accumulates @loc and @ncloc equal to total lines', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0, '3': 1 });
+    const result = handler.finalize();
+    const m = result.coverage.project.metrics;
+    expect(m['@loc']).toBe(3);
+    expect(m['@ncloc']).toBe(3);
+  });
+
+  it('keeps @conditionals and @coveredconditionals at 0', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage.project.metrics['@conditionals']).toBe(0);
+    expect(result.coverage.project.metrics['@coveredconditionals']).toBe(0);
+  });
+
+  it('sorts files by @path in finalize', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage.project.file[0]['@path']).toBe('a/First.cls');
+    expect(result.coverage.project.file[1]['@path']).toBe('z/Last.cls');
+  });
+
+  it('sets @name on each file object', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage.project.file[0]['@name']).toBe('Foo');
+  });
+
+  it('handles empty lines object without crashing', () => {
+    const handler = new CloverCoverageHandler();
+    handler.processFile('empty.cls', 'Empty', {});
+    const result = handler.finalize();
+    expect(result.coverage.project.file[0].line).toEqual([]);
+    expect(result.coverage.project.metrics['@statements']).toBe(0);
+  });
+});

--- a/test/units/coberturaHandlerExpanded.test.ts
+++ b/test/units/coberturaHandlerExpanded.test.ts
@@ -1,0 +1,91 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { CoberturaCoverageHandler } from '../../src/handlers/cobertura.js';
+
+describe('CoberturaCoverageHandler expanded unit tests', () => {
+  it('sets @line-rate based on coveredLines / totalLines per class', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 1, '3': 0, '4': 0 });
+    const result = handler.finalize();
+    const cls = result.coverage.packages.package[0].classes.class[0];
+    // 2/4 = 0.5
+    expect(cls['@line-rate']).toBe(0.5);
+  });
+
+  it('populates line hits correctly: @hits=1 for covered, @hits=0 for uncovered', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const lines = result.coverage.packages.package[0].classes.class[0].lines.line;
+    const line1 = lines.find((l) => l['@number'] === 1);
+    const line2 = lines.find((l) => l['@number'] === 2);
+    expect(line1?.['@hits']).toBe(1);
+    expect(line2?.['@hits']).toBe(0);
+  });
+
+  it('sets @branch="false" on every line', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 0, '3': 1 });
+    const result = handler.finalize();
+    const lines = result.coverage.packages.package[0].classes.class[0].lines.line;
+    expect(lines.every((l) => l['@branch'] === 'false')).toBe(true);
+  });
+
+  it('accumulates @lines-valid and @lines-covered across files', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 0 });
+    handler.processFile('pkg/B.cls', 'B', { '1': 1, '2': 1 });
+    const result = handler.finalize();
+    expect(result.coverage['@lines-valid']).toBe(4);
+    expect(result.coverage['@lines-covered']).toBe(3);
+  });
+
+  it('computes global @line-rate correctly', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 1, '3': 1, '4': 0 });
+    const result = handler.finalize();
+    // 3/4 = 0.75
+    expect(result.coverage['@line-rate']).toBe(0.75);
+  });
+
+  it('@branch-rate is 1 on both class and global', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage['@branch-rate']).toBe(1);
+    expect(result.coverage.packages.package[0]['@branch-rate']).toBe(1);
+  });
+
+  it('groups files from same root directory into same package', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('force-app/A.cls', 'A', { '1': 1 });
+    handler.processFile('force-app/B.cls', 'B', { '1': 0 });
+    const result = handler.finalize();
+    expect(result.coverage.packages.package).toHaveLength(1);
+    expect(result.coverage.packages.package[0]['@name']).toBe('force-app');
+  });
+
+  it('creates separate packages for different root directories', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('force-app/A.cls', 'A', { '1': 1 });
+    handler.processFile('packaged/B.cls', 'B', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage.packages.package).toHaveLength(2);
+  });
+
+  it('@complexity is 0 on coverage element', () => {
+    const handler = new CoberturaCoverageHandler();
+    const result = handler.finalize();
+    expect(result.coverage['@complexity']).toBe(0);
+  });
+
+  it('@branches-valid and @branches-covered are 0', () => {
+    const handler = new CoberturaCoverageHandler();
+    handler.processFile('pkg/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage['@branches-valid']).toBe(0);
+    expect(result.coverage['@branches-covered']).toBe(0);
+  });
+});

--- a/test/units/generateGitHubActionsUnit.test.ts
+++ b/test/units/generateGitHubActionsUnit.test.ts
@@ -1,0 +1,98 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { generateGitHubActions } from '../../src/transformers/generators/generateGitHubActions.js';
+import type { GitHubActionsCoverageObject } from '../../src/utils/types.js';
+
+function makeObj(overrides: Partial<GitHubActionsCoverageObject> = {}): GitHubActionsCoverageObject {
+  return {
+    summary: { totalLines: 0, coveredLines: 0, uncoveredLines: 0, lineRate: 0, fileCount: 0 },
+    uncoveredLines: [],
+    ...overrides,
+  };
+}
+
+describe('generateGitHubActions unit tests', () => {
+  it('uses singular "file" when fileCount is 1', () => {
+    const obj = makeObj({ summary: { totalLines: 2, coveredLines: 2, uncoveredLines: 0, lineRate: 1, fileCount: 1 } });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('1 file)');
+    expect(result).not.toContain('1 files');
+  });
+
+  it('uses plural "files" when fileCount is 2', () => {
+    const obj = makeObj({ summary: { totalLines: 4, coveredLines: 4, uncoveredLines: 0, lineRate: 1, fileCount: 2 } });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('2 files');
+  });
+
+  it('escapes % in the coverage percentage', () => {
+    const obj = makeObj({
+      summary: { totalLines: 3, coveredLines: 1, uncoveredLines: 2, lineRate: 1 / 3, fileCount: 1 },
+    });
+    const result = generateGitHubActions(obj);
+    // % in data must be encoded as %25
+    expect(result).toContain('%25');
+  });
+
+  it('escapes % in file path property value', () => {
+    const obj = makeObj({
+      summary: { totalLines: 1, coveredLines: 0, uncoveredLines: 1, lineRate: 0, fileCount: 1 },
+      uncoveredLines: [{ filePath: 'force-app/50%Class.cls', lineNumber: 1 }],
+    });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('force-app/50%25Class.cls');
+  });
+
+  it('escapes colon in file path property value', () => {
+    const obj = makeObj({
+      summary: { totalLines: 1, coveredLines: 0, uncoveredLines: 1, lineRate: 0, fileCount: 1 },
+      uncoveredLines: [{ filePath: 'force-app/C:D.cls', lineNumber: 1 }],
+    });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('C%3AD');
+  });
+
+  it('escapes comma in file path property value', () => {
+    const obj = makeObj({
+      summary: { totalLines: 1, coveredLines: 0, uncoveredLines: 1, lineRate: 0, fileCount: 1 },
+      uncoveredLines: [{ filePath: 'force-app/A,B.cls', lineNumber: 1 }],
+    });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('A%2CB');
+  });
+
+  it('summary line starts with ::notice title=Apex Code Coverage::', () => {
+    const obj = makeObj();
+    const result = generateGitHubActions(obj);
+    expect(result.split('\n')[0]).toContain('::notice title=Apex Code Coverage::');
+  });
+
+  it('annotation line contains ::warning file=...,line=...,title=...::...', () => {
+    const obj = makeObj({
+      summary: { totalLines: 1, coveredLines: 0, uncoveredLines: 1, lineRate: 0, fileCount: 1 },
+      uncoveredLines: [{ filePath: 'src/Foo.cls', lineNumber: 7 }],
+    });
+    const result = generateGitHubActions(obj);
+    expect(result).toContain('::warning file=src/Foo.cls,line=7,title=Uncovered Apex line::');
+  });
+
+  it('uses custom maxAnnotations limit', () => {
+    const lines = Array.from({ length: 10 }, (_, i) => ({ filePath: 'a.cls', lineNumber: i + 1 }));
+    const obj = makeObj({
+      summary: { totalLines: 10, coveredLines: 0, uncoveredLines: 10, lineRate: 0, fileCount: 1 },
+      uncoveredLines: lines,
+    });
+    const result = generateGitHubActions(obj, 3);
+    const warnings = result.split('\n').filter((l) => l.startsWith('::warning'));
+    expect(warnings).toHaveLength(3);
+  });
+
+  it('emits no warning lines when there are no uncovered lines', () => {
+    const obj = makeObj({ summary: { totalLines: 5, coveredLines: 5, uncoveredLines: 0, lineRate: 1, fileCount: 1 } });
+    const result = generateGitHubActions(obj);
+    const warnings = result.split('\n').filter((l) => l.startsWith('::warning'));
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/test/units/generateHtmlUnit.test.ts
+++ b/test/units/generateHtmlUnit.test.ts
@@ -1,0 +1,177 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { generateHtml } from '../../src/transformers/generators/generateHtml.js';
+import type { HtmlCoverageObject } from '../../src/utils/types.js';
+
+function makeObj(overrides: Partial<HtmlCoverageObject> = {}): HtmlCoverageObject {
+  return {
+    summary: { totalLines: 0, coveredLines: 0, uncoveredLines: 0, lineRate: 0 },
+    packageSummaries: [],
+    files: [],
+    ...overrides,
+  };
+}
+
+describe('generateHtml unit tests', () => {
+  it('uses green color (#4caf50) for coverage >= 80%', () => {
+    const obj = makeObj({ summary: { totalLines: 10, coveredLines: 8, uncoveredLines: 2, lineRate: 0.8 } });
+    const result = generateHtml(obj);
+    expect(result).toContain('#4caf50');
+  });
+
+  it('uses orange color (#ff9800) for coverage >= 60% and < 80%', () => {
+    const obj = makeObj({ summary: { totalLines: 10, coveredLines: 7, uncoveredLines: 3, lineRate: 0.7 } });
+    const result = generateHtml(obj);
+    // Note: summary color would be orange since 70% is in [60%, 80%)
+    expect(result).toContain('#ff9800');
+  });
+
+  it('uses red color (#f44336) for coverage < 60%', () => {
+    const obj = makeObj({ summary: { totalLines: 10, coveredLines: 5, uncoveredLines: 5, lineRate: 0.5 } });
+    const result = generateHtml(obj);
+    expect(result).toContain('#f44336');
+  });
+
+  it('formats coverage as 2 decimal places (without % in formatPercent itself)', () => {
+    const obj = makeObj({ summary: { totalLines: 3, coveredLines: 1, uncoveredLines: 2, lineRate: 1 / 3 } });
+    const result = generateHtml(obj);
+    // 33.33 should appear in the output (formatPercent returns "33.33" not "33.33%")
+    expect(result).toContain('33.33');
+  });
+
+  it('includes package summary table when packageSummaries is non-empty', () => {
+    const obj = makeObj({
+      packageSummaries: [
+        {
+          directory: 'force-app',
+          fileCount: 2,
+          totalLines: 10,
+          coveredLines: 8,
+          uncoveredLines: 2,
+          lineRate: 0.8,
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('Package directory coverage');
+    expect(result).toContain('force-app');
+  });
+
+  it('omits package summary table when packageSummaries is empty', () => {
+    const obj = makeObj();
+    const result = generateHtml(obj);
+    expect(result).not.toContain('Package directory coverage');
+  });
+
+  it('marks covered lines with class "covered" and green background', () => {
+    const obj = makeObj({
+      files: [
+        {
+          filePath: 'src/A.cls',
+          fileName: 'A',
+          totalLines: 1,
+          coveredLines: 1,
+          uncoveredLines: 0,
+          lineRate: 1,
+          lines: [{ lineNumber: 1, hitCount: 1, covered: true, content: 'foo' }],
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('class="covered"');
+    expect(result).toContain('#c8e6c9');
+  });
+
+  it('marks uncovered lines with class "uncovered" and red background', () => {
+    const obj = makeObj({
+      files: [
+        {
+          filePath: 'src/A.cls',
+          fileName: 'A',
+          totalLines: 1,
+          coveredLines: 0,
+          uncoveredLines: 1,
+          lineRate: 0,
+          lines: [{ lineNumber: 1, hitCount: 0, covered: false, content: 'bar' }],
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('class="uncovered"');
+    expect(result).toContain('#ffcdd2');
+  });
+
+  it('escapes HTML special characters in line content', () => {
+    const obj = makeObj({
+      files: [
+        {
+          filePath: 'src/A.cls',
+          fileName: 'A',
+          totalLines: 1,
+          coveredLines: 1,
+          uncoveredLines: 0,
+          lineRate: 1,
+          lines: [{ lineNumber: 1, hitCount: 1, covered: true, content: '<script>alert("xss")</script>' }],
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('&lt;script&gt;');
+    expect(result).toContain('&quot;xss&quot;');
+    expect(result).not.toContain('<script>alert');
+  });
+
+  it('groups files by directory in the output', () => {
+    const obj = makeObj({
+      files: [
+        {
+          filePath: 'a-dir/A.cls',
+          fileName: 'A',
+          totalLines: 1,
+          coveredLines: 1,
+          uncoveredLines: 0,
+          lineRate: 1,
+          lines: [],
+        },
+        {
+          filePath: 'b-dir/B.cls',
+          fileName: 'B',
+          totalLines: 1,
+          coveredLines: 0,
+          uncoveredLines: 1,
+          lineRate: 0,
+          lines: [],
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('a-dir/');
+    expect(result).toContain('b-dir/');
+  });
+
+  it('always contains the Code Coverage Report title', () => {
+    const obj = makeObj();
+    const result = generateHtml(obj);
+    expect(result).toContain('Code Coverage Report');
+  });
+
+  it('package summary row includes directory name, fileCount, and coverage percent', () => {
+    const obj = makeObj({
+      packageSummaries: [
+        {
+          directory: 'force-app',
+          fileCount: 3,
+          totalLines: 10,
+          coveredLines: 8,
+          uncoveredLines: 2,
+          lineRate: 0.8,
+        },
+      ],
+    });
+    const result = generateHtml(obj);
+    expect(result).toContain('force-app');
+    expect(result).toContain('80.00');
+  });
+});

--- a/test/units/generateMarkdownUnit.test.ts
+++ b/test/units/generateMarkdownUnit.test.ts
@@ -1,0 +1,100 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { generateMarkdown } from '../../src/transformers/generators/generateMarkdown.js';
+import type { MarkdownCoverageObject } from '../../src/utils/types.js';
+
+function makeObj(overrides: Partial<MarkdownCoverageObject> = {}): MarkdownCoverageObject {
+  return {
+    summary: { totalLines: 0, coveredLines: 0, uncoveredLines: 0, lineRate: 0, fileCount: 0 },
+    packages: [],
+    files: [],
+    ...overrides,
+  };
+}
+
+describe('generateMarkdown unit tests', () => {
+  it('uses singular "file" when fileCount is 1', () => {
+    const obj = makeObj({
+      summary: { totalLines: 10, coveredLines: 8, uncoveredLines: 2, lineRate: 0.8, fileCount: 1 },
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('1 file)');
+    expect(result).not.toContain('1 files');
+  });
+
+  it('uses plural "files" when fileCount is 2', () => {
+    const obj = makeObj({
+      summary: { totalLines: 10, coveredLines: 8, uncoveredLines: 2, lineRate: 0.8, fileCount: 2 },
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('2 files');
+  });
+
+  it('omits package table section when packages is empty', () => {
+    const obj = makeObj();
+    const result = generateMarkdown(obj);
+    expect(result).not.toContain('## Package directory coverage');
+  });
+
+  it('includes package table section when packages is non-empty', () => {
+    const obj = makeObj({
+      packages: [
+        { directory: 'force-app', fileCount: 1, totalLines: 5, coveredLines: 4, uncoveredLines: 1, lineRate: 0.8 },
+      ],
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('## Package directory coverage');
+    expect(result).toContain('force-app');
+  });
+
+  it('omits file table section when files is empty', () => {
+    const obj = makeObj();
+    const result = generateMarkdown(obj);
+    expect(result).not.toContain('## File coverage');
+  });
+
+  it('includes file table section when files is non-empty', () => {
+    const obj = makeObj({
+      files: [{ filePath: 'force-app/main/Foo.cls', totalLines: 5, coveredLines: 4, uncoveredLines: 1, lineRate: 0.8 }],
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('## File coverage');
+    expect(result).toContain('force-app/main/Foo.cls');
+  });
+
+  it('formats line rate as percentage with 2 decimal places', () => {
+    const obj = makeObj({
+      summary: { totalLines: 3, coveredLines: 1, uncoveredLines: 2, lineRate: 1 / 3, fileCount: 1 },
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('33.33%');
+  });
+
+  it('always includes the summary heading', () => {
+    const obj = makeObj();
+    const result = generateMarkdown(obj);
+    expect(result).toContain('# Apex Code Coverage Report');
+  });
+
+  it('package table header contains expected columns', () => {
+    const obj = makeObj({
+      packages: [
+        { directory: 'force-app', fileCount: 1, totalLines: 2, coveredLines: 1, uncoveredLines: 1, lineRate: 0.5 },
+      ],
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('Directory');
+    expect(result).toContain('Files');
+    expect(result).toContain('Coverage');
+  });
+
+  it('file table includes "sorted with lowest coverage first" note', () => {
+    const obj = makeObj({
+      files: [{ filePath: 'a.cls', totalLines: 2, coveredLines: 1, uncoveredLines: 1, lineRate: 0.5 }],
+    });
+    const result = generateMarkdown(obj);
+    expect(result).toContain('lowest coverage first');
+  });
+});

--- a/test/units/getConcurrencyThreshold.test.ts
+++ b/test/units/getConcurrencyThreshold.test.ts
@@ -1,0 +1,23 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { getConcurrencyThreshold } from '../../src/utils/getConcurrencyThreshold.js';
+
+describe('getConcurrencyThreshold', () => {
+  it('returns a positive integer', () => {
+    const result = getConcurrencyThreshold();
+    expect(result).toBeGreaterThan(0);
+    expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('returns at most 6', () => {
+    const result = getConcurrencyThreshold();
+    expect(result).toBeLessThanOrEqual(6);
+  });
+
+  it('returns at least 1', () => {
+    const result = getConcurrencyThreshold();
+    expect(result).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/test/units/istanbulHandler.test.ts
+++ b/test/units/istanbulHandler.test.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { IstanbulCoverageHandler } from '../../src/handlers/istanbulJson.js';
+
+describe('IstanbulCoverageHandler unit tests', () => {
+  it('sets path to filePath argument', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('force-app/classes/Foo.cls', 'Foo', { '1': 1 });
+    const result = handler.finalize();
+    expect(result['force-app/classes/Foo.cls'].path).toBe('force-app/classes/Foo.cls');
+  });
+
+  it('builds statementMap with correct start/end line and column=0', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '5': 1, '10': 0 });
+    const result = handler.finalize();
+    const stmtMap = result['src/A.cls'].statementMap;
+    expect(stmtMap['5']).toEqual({ start: { line: 5, column: 0 }, end: { line: 5, column: 0 } });
+    expect(stmtMap['10']).toEqual({ start: { line: 10, column: 0 }, end: { line: 10, column: 0 } });
+  });
+
+  it('populates s (statement hits) with the raw hit count', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    expect(result['src/A.cls'].s['1']).toBe(1);
+    expect(result['src/A.cls'].s['2']).toBe(0);
+  });
+
+  it('populates l (line coverage) with the raw hit count', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '3': 1, '7': 0 });
+    const result = handler.finalize();
+    expect(result['src/A.cls'].l['3']).toBe(1);
+    expect(result['src/A.cls'].l['7']).toBe(0);
+  });
+
+  it('fnMap, f, branchMap, b are empty objects', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    const file = result['src/A.cls'];
+    expect(file.fnMap).toEqual({});
+    expect(file.f).toEqual({});
+    expect(file.branchMap).toEqual({});
+    expect(file.b).toEqual({});
+  });
+
+  it('sorts output by file path in finalize', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    handler.processFile('m/Middle.cls', 'Middle', { '1': 1 });
+    const result = handler.finalize();
+    const keys = Object.keys(result);
+    expect(keys[0]).toBe('a/First.cls');
+    expect(keys[1]).toBe('m/Middle.cls');
+    expect(keys[2]).toBe('z/Last.cls');
+  });
+
+  it('start and end line are both the same line number', () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '42': 1 });
+    const result = handler.finalize();
+    const stmtEntry = result['src/A.cls'].statementMap['42'];
+    expect(stmtEntry.start.line).toBe(42);
+    expect(stmtEntry.end.line).toBe(42);
+  });
+});

--- a/test/units/jacocoHandler.test.ts
+++ b/test/units/jacocoHandler.test.ts
@@ -1,0 +1,116 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { JaCoCoCoverageHandler } from '../../src/handlers/jacoco.js';
+
+describe('JaCoCoCoverageHandler unit tests', () => {
+  it('sets @mi=0, @ci=1 for covered lines', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '5': 1 });
+    const result = handler.finalize();
+    const pkg = result.report.package[0];
+    const sf = pkg.sourcefile[0];
+    const line = sf.line.find((l) => l['@nr'] === 5);
+    expect(line?.['@mi']).toBe(0);
+    expect(line?.['@ci']).toBe(1);
+  });
+
+  it('sets @mi=1, @ci=0 for uncovered lines', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '3': 0 });
+    const result = handler.finalize();
+    const pkg = result.report.package[0];
+    const sf = pkg.sourcefile[0];
+    const line = sf.line.find((l) => l['@nr'] === 3);
+    expect(line?.['@mi']).toBe(1);
+    expect(line?.['@ci']).toBe(0);
+  });
+
+  it('always sets @mb=0 and @cb=0', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const sf = result.report.package[0].sourcefile[0];
+    expect(sf.line.every((l) => l['@mb'] === 0)).toBe(true);
+    expect(sf.line.every((l) => l['@cb'] === 0)).toBe(true);
+  });
+
+  it('records correct @nr (line number) for each line', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '10': 1, '20': 0 });
+    const result = handler.finalize();
+    const nums = result.report.package[0].sourcefile[0].line.map((l) => l['@nr']);
+    expect(nums).toContain(10);
+    expect(nums).toContain(20);
+  });
+
+  it('source file counter @missed and @covered are correct', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1, '2': 0, '3': 1, '4': 0, '5': 1 });
+    const result = handler.finalize();
+    const sfCounter = result.report.package[0].sourcefile[0].counter[0];
+    expect(sfCounter['@type']).toBe('LINE');
+    expect(sfCounter['@covered']).toBe(3);
+    expect(sfCounter['@missed']).toBe(2);
+  });
+
+  it('package counter accumulates across source files', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1, '2': 0 });
+    handler.processFile('force-app/classes/B.cls', 'B', { '1': 1, '2': 1 });
+    const result = handler.finalize();
+    const pkgCounter = result.report.package[0].counter[0];
+    expect(pkgCounter['@covered']).toBe(3);
+    expect(pkgCounter['@missed']).toBe(1);
+  });
+
+  it('global counter accumulates across packages', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1 });
+    handler.processFile('packaged/triggers/B.trigger', 'B', { '1': 0 });
+    const result = handler.finalize();
+    const globalCounter = result.report.counter[0];
+    expect(globalCounter['@covered']).toBe(1);
+    expect(globalCounter['@missed']).toBe(1);
+  });
+
+  it('sorts packages by name', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('z-pkg/classes/A.cls', 'A', { '1': 1 });
+    handler.processFile('a-pkg/classes/B.cls', 'B', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.report.package[0]['@name']).toBe('a-pkg/classes');
+    expect(result.report.package[1]['@name']).toBe('z-pkg/classes');
+  });
+
+  it('sorts source files within a package by name', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/Z.cls', 'Z', { '1': 1 });
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    const names = result.report.package[0].sourcefile.map((sf) => sf['@name']);
+    expect(names[0]).toBe('A.cls');
+    expect(names[1]).toBe('Z.cls');
+  });
+
+  it('uses only the filename (not full path) as source file @name', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Foo.cls', 'Foo', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.report.package[0].sourcefile[0]['@name']).toBe('Foo.cls');
+  });
+
+  it('package @name is the path excluding the filename', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/main/default/classes/Foo.cls', 'Foo', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.report.package[0]['@name']).toBe('force-app/main/default/classes');
+  });
+
+  it('report @name is "JaCoCo"', () => {
+    const handler = new JaCoCoCoverageHandler();
+    const result = handler.finalize();
+    expect(result.report['@name']).toBe('JaCoCo');
+  });
+});

--- a/test/units/jsonSummaryExpanded.test.ts
+++ b/test/units/jsonSummaryExpanded.test.ts
@@ -1,0 +1,62 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { JsonSummaryCoverageHandler } from '../../src/handlers/jsonSummary.js';
+
+describe('JsonSummaryCoverageHandler expanded unit tests', () => {
+  it('sorts file entries by path in finalize', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    handler.processFile('m/Middle.cls', 'Middle', { '1': 1 });
+    const result = handler.finalize();
+    const keys = Object.keys(result.files);
+    expect(keys[0]).toBe('a/First.cls');
+    expect(keys[1]).toBe('m/Middle.cls');
+    expect(keys[2]).toBe('z/Last.cls');
+  });
+
+  it('accumulates total lines across multiple files', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0 });
+    handler.processFile('b.cls', 'B', { '1': 1, '2': 1, '3': 0 });
+    const result = handler.finalize();
+    expect(result.total.lines.total).toBe(5);
+    expect(result.total.lines.covered).toBe(3);
+  });
+
+  it('sets total pct to 0 when no lines', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    const result = handler.finalize();
+    expect(result.total.lines.pct).toBe(0);
+    expect(result.total.lines.total).toBe(0);
+  });
+
+  it('statements mirror lines values', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0, '3': 1 });
+    const result = handler.finalize();
+    expect(result.total.statements.total).toBe(result.total.lines.total);
+    expect(result.total.statements.covered).toBe(result.total.lines.covered);
+    expect(result.total.statements.pct).toBe(result.total.lines.pct);
+  });
+
+  it('file-level statements mirror file-level lines', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const file = result.files['a.cls'];
+    expect(file.statements.total).toBe(file.lines.total);
+    expect(file.statements.covered).toBe(file.lines.covered);
+    expect(file.statements.pct).toBe(file.lines.pct);
+  });
+
+  it('skipped is always 0', () => {
+    const handler = new JsonSummaryCoverageHandler();
+    handler.processFile('a.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    expect(result.total.lines.skipped).toBe(0);
+    expect(result.files['a.cls'].lines.skipped).toBe(0);
+  });
+});

--- a/test/units/lcovHandler.test.ts
+++ b/test/units/lcovHandler.test.ts
@@ -1,0 +1,71 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { LcovCoverageHandler } from '../../src/handlers/lcov.js';
+
+describe('LcovCoverageHandler unit tests', () => {
+  it('sets hitCount=1 for covered lines, hitCount=0 for uncovered', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    const { lines } = result.files[0];
+    const line1 = lines.find((l) => l.lineNumber === 1);
+    const line2 = lines.find((l) => l.lineNumber === 2);
+    expect(line1?.hitCount).toBe(1);
+    expect(line2?.hitCount).toBe(0);
+  });
+
+  it('records correct line numbers in lines array', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '5': 1, '10': 0, '15': 1 });
+    const result = handler.finalize();
+    const nums = result.files[0].lines.map((l) => l.lineNumber);
+    expect(nums).toContain(5);
+    expect(nums).toContain(10);
+    expect(nums).toContain(15);
+  });
+
+  it('calculates totalLines and coveredLines correctly', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0, '3': 1, '4': 1 });
+    const result = handler.finalize();
+    expect(result.files[0].totalLines).toBe(4);
+    expect(result.files[0].coveredLines).toBe(3);
+  });
+
+  it('sets sourceFile to the filePath argument', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('force-app/classes/Foo.cls', 'Foo', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.files[0].sourceFile).toBe('force-app/classes/Foo.cls');
+  });
+
+  it('sorts files by sourceFile in finalize', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    handler.processFile('m/Middle.cls', 'Middle', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.files[0].sourceFile).toBe('a/First.cls');
+    expect(result.files[1].sourceFile).toBe('m/Middle.cls');
+    expect(result.files[2].sourceFile).toBe('z/Last.cls');
+  });
+
+  it('handles empty lines object with zero totals', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('src/Empty.cls', 'Empty', {});
+    const result = handler.finalize();
+    expect(result.files[0].totalLines).toBe(0);
+    expect(result.files[0].coveredLines).toBe(0);
+    expect(result.files[0].lines).toEqual([]);
+  });
+
+  it('accumulates multiple files', () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('a/A.cls', 'A', { '1': 1 });
+    handler.processFile('b/B.cls', 'B', { '1': 0 });
+    const result = handler.finalize();
+    expect(result.files).toHaveLength(2);
+  });
+});

--- a/test/units/normalizePathToUnix.test.ts
+++ b/test/units/normalizePathToUnix.test.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { normalizePathToUnix } from '../../src/utils/normalizePathToUnix.js';
+
+describe('normalizePathToUnix', () => {
+  it('replaces backslashes with forward slashes', () => {
+    expect(normalizePathToUnix('a\\b\\c')).toBe('a/b/c');
+  });
+
+  it('replaces multiple consecutive backslashes', () => {
+    expect(normalizePathToUnix('a\\\\b')).toBe('a//b');
+  });
+
+  it('leaves forward slashes unchanged', () => {
+    expect(normalizePathToUnix('a/b/c')).toBe('a/b/c');
+  });
+
+  it('handles mixed slashes', () => {
+    expect(normalizePathToUnix('force-app\\main\\default/classes/Foo.cls')).toBe(
+      'force-app/main/default/classes/Foo.cls',
+    );
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(normalizePathToUnix('')).toBe('');
+  });
+
+  it('handles paths with no slashes', () => {
+    expect(normalizePathToUnix('Foo.cls')).toBe('Foo.cls');
+  });
+});

--- a/test/units/opencoverHandlerExpanded.test.ts
+++ b/test/units/opencoverHandlerExpanded.test.ts
@@ -1,0 +1,92 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { OpenCoverCoverageHandler } from '../../src/handlers/opencover.js';
+
+describe('OpenCoverCoverageHandler expanded unit tests', () => {
+  it('calculates @sequenceCoverage correctly when numSequencePoints > 0', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 1, '3': 0, '4': 0 });
+    const result = handler.finalize();
+    const summary = result.CoverageSession.Summary;
+    // 2 covered out of 4 total = 50%
+    expect(summary['@numSequencePoints']).toBe(4);
+    expect(summary['@visitedSequencePoints']).toBe(2);
+    expect(summary['@sequenceCoverage']).toBe(50);
+  });
+
+  it('sets @branchCoverage to 0 always', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.CoverageSession.Summary['@branchCoverage']).toBe(0);
+  });
+
+  it('sequence points have correct @vc, @sl, @el values', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '5': 1, '10': 0 });
+    const result = handler.finalize();
+    const cls = result.CoverageSession.Modules.Module[0].Classes.Class[0];
+    const method = cls.Methods.Method[0];
+    const sp5 = method.SequencePoints.SequencePoint.find((sp) => sp['@sl'] === 5);
+    const sp10 = method.SequencePoints.SequencePoint.find((sp) => sp['@sl'] === 10);
+    expect(sp5?.['@vc']).toBe(1);
+    expect(sp5?.['@el']).toBe(5);
+    expect(sp5?.['@sc']).toBe(0);
+    expect(sp5?.['@ec']).toBe(0);
+    expect(sp10?.['@vc']).toBe(0);
+  });
+
+  it('@isConstructor and @isStatic are always false on methods', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    const method = result.CoverageSession.Modules.Module[0].Classes.Class[0].Methods.Method[0];
+    expect(method['@isConstructor']).toBe(false);
+    expect(method['@isStatic']).toBe(false);
+  });
+
+  it('sorts classes by @fullName', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('z/Z.cls', 'ZClass', { '1': 1 });
+    handler.processFile('a/A.cls', 'AClass', { '1': 1 });
+    const result = handler.finalize();
+    const classes = result.CoverageSession.Modules.Module[0].Classes.Class;
+    expect(classes[0]['@fullName']).toBe('AClass');
+    expect(classes[1]['@fullName']).toBe('ZClass');
+  });
+
+  it('accumulates numSequencePoints and visitedSequencePoints across files', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('a/A.cls', 'A', { '1': 1, '2': 0 });
+    handler.processFile('b/B.cls', 'B', { '1': 1, '2': 1, '3': 0 });
+    const result = handler.finalize();
+    const summary = result.CoverageSession.Summary;
+    expect(summary['@numSequencePoints']).toBe(5);
+    expect(summary['@visitedSequencePoints']).toBe(3);
+  });
+
+  it('reassigns UIDs starting from 1 in sorted order', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('c/C.cls', 'C', { '1': 1 });
+    handler.processFile('a/A.cls', 'A', { '1': 1 });
+    handler.processFile('b/B.cls', 'B', { '1': 1 });
+    const result = handler.finalize();
+    const files = result.CoverageSession.Modules.Module[0].Files.File;
+    expect(files[0]['@fullPath']).toBe('a/A.cls');
+    expect(files[0]['@uid']).toBe(1);
+    expect(files[1]['@fullPath']).toBe('b/B.cls');
+    expect(files[1]['@uid']).toBe(2);
+    expect(files[2]['@fullPath']).toBe('c/C.cls');
+    expect(files[2]['@uid']).toBe(3);
+  });
+
+  it('@sequenceCoverage is rounded to 2 decimal places', () => {
+    const handler = new OpenCoverCoverageHandler();
+    // 1 out of 3 = 33.333...% → should round to 33.33
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0, '3': 0 });
+    const result = handler.finalize();
+    expect(result.CoverageSession.Summary['@sequenceCoverage']).toBe(33.33);
+  });
+});

--- a/test/units/reportGeneratorUnit.test.ts
+++ b/test/units/reportGeneratorUnit.test.ts
@@ -1,0 +1,147 @@
+'use strict';
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { generateAndWriteReport, getExtensionForFormat } from '../../src/transformers/reportGenerator.js';
+import { LcovCoverageHandler } from '../../src/handlers/lcov.js';
+import { SonarCoverageHandler } from '../../src/handlers/sonar.js';
+import { IstanbulCoverageHandler } from '../../src/handlers/istanbulJson.js';
+import { CoberturaCoverageHandler } from '../../src/handlers/cobertura.js';
+
+// Ensure all handlers are registered
+import '../../src/handlers/getHandler.js';
+
+describe('reportGenerator unit tests', () => {
+  it('produces correct LCOV format (TN:, SF:, DA:, LF:, LH:, BRF:, BRH:, end_of_record)', async () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0, '3': 1 });
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'lcov-report-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.info'), coverageObj, 'lcovonly', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('TN:');
+      expect(content).toContain('SF:src/A.cls');
+      expect(content).toContain('DA:1,1');
+      expect(content).toContain('DA:2,0');
+      expect(content).toContain('DA:3,1');
+      expect(content).toContain('LF:3');
+      expect(content).toContain('LH:2');
+      expect(content).toContain('FNF:0');
+      expect(content).toContain('FNH:0');
+      expect(content).toContain('BRF:0');
+      expect(content).toContain('BRH:0');
+      expect(content).toContain('end_of_record');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('uses no suffix in filename when formatAmount is 1', async () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'single-format-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.xml'), coverageObj, 'sonar', 1);
+      expect(outPath).toContain('coverage.xml');
+      expect(outPath).not.toContain('-sonar');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('appends -format suffix in filename when formatAmount > 1', async () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'multi-format-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.xml'), coverageObj, 'sonar', 3);
+      expect(outPath).toContain('-sonar');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('produces valid JSON for the "json" format', async () => {
+    const handler = new IstanbulCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '2': 0 });
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'json-format-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.json'), coverageObj, 'json', 1);
+      const content = await readFile(outPath, 'utf-8');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const parsed = JSON.parse(content);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(parsed['src/A.cls']).toBeDefined();
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('produces XML with DOCTYPE for cobertura format', async () => {
+    const handler = new CoberturaCoverageHandler();
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'cobertura-hdr-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.xml'), coverageObj, 'cobertura', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('<?xml version="1.0" ?>');
+      expect(content).toContain('<!DOCTYPE coverage');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('produces XML without DOCTYPE for sonar format', async () => {
+    const handler = new SonarCoverageHandler();
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'sonar-hdr-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.xml'), coverageObj, 'sonar', 1);
+      const content = await readFile(outPath, 'utf-8');
+      expect(content).toContain('<?xml version="1.0"?>');
+      expect(content).not.toContain('<!DOCTYPE');
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it('getExtensionForFormat returns correct extension', () => {
+    expect(getExtensionForFormat('sonar')).toBe('.xml');
+    expect(getExtensionForFormat('json')).toBe('.json');
+    expect(getExtensionForFormat('lcovonly')).toBe('.info');
+    expect(getExtensionForFormat('html')).toBe('.html');
+    expect(getExtensionForFormat('markdown')).toBe('.md');
+    expect(getExtensionForFormat('github-actions')).toBe('.txt');
+    expect(getExtensionForFormat('unknown-xyz')).toBe('.xml');
+  });
+
+  it('LCOV output for multiple files is separated by newline', async () => {
+    const handler = new LcovCoverageHandler();
+    handler.processFile('a/A.cls', 'A', { '1': 1 });
+    handler.processFile('b/B.cls', 'B', { '2': 0 });
+    const coverageObj = handler.finalize();
+
+    const tmpDir = await mkdtemp(join(tmpdir(), 'lcov-multi-'));
+    try {
+      const outPath = await generateAndWriteReport(join(tmpDir, 'coverage.info'), coverageObj, 'lcovonly', 1);
+      const content = await readFile(outPath, 'utf-8');
+      const endRecords = (content.match(/end_of_record/g) ?? []).length;
+      expect(endRecords).toBe(2);
+    } finally {
+      await rm(tmpDir, { recursive: true });
+    }
+  });
+});

--- a/test/units/setCoverageDataTypeExpanded.test.ts
+++ b/test/units/setCoverageDataTypeExpanded.test.ts
@@ -1,0 +1,125 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+import { checkCoverageDataType } from '../../src/utils/setCoverageDataType.js';
+import { DeployCoverageData, TestCoverageData } from '../../src/utils/types.js';
+
+const validDeployItem = {
+  path: 'some/file.cls',
+  fnMap: {},
+  branchMap: {},
+  f: {},
+  b: {},
+  s: { '1': 1, '2': 0 },
+  statementMap: {
+    '1': { start: { line: 1, column: 0 }, end: { line: 1, column: 10 } },
+    '2': { start: { line: 2, column: 0 }, end: { line: 2, column: 10 } },
+  },
+};
+
+const validTestItem: TestCoverageData = {
+  id: 'abc123',
+  name: 'MyClass',
+  totalLines: 5,
+  coveredPercent: 80,
+  totalCovered: 4,
+  lines: { '1': 1, '2': 0 },
+};
+
+describe('checkCoverageDataType expanded tests', () => {
+  it('returns DeployCoverageData for valid deploy JSON', () => {
+    const data = { MyClass: validDeployItem };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('DeployCoverageData');
+  });
+
+  it('returns TestCoverageData for valid test JSON array', () => {
+    const data = [validTestItem];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('TestCoverageData');
+  });
+
+  it('returns Unknown when deploy item missing path field', () => {
+    const data = { MyClass: { ...validDeployItem, path: undefined } };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when deploy item missing fnMap field', () => {
+    const data = { MyClass: { ...validDeployItem, fnMap: undefined } };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when deploy item missing s field', () => {
+    const data = { MyClass: { ...validDeployItem, s: undefined } };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when statementMap has invalid start position (missing line)', () => {
+    const badItem = {
+      ...validDeployItem,
+      statementMap: {
+        '1': { start: { column: 0 }, end: { line: 1, column: 0 } },
+      },
+    };
+    const data = { MyClass: badItem };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when statementMap has invalid end position (missing column)', () => {
+    const badItem = {
+      ...validDeployItem,
+      statementMap: {
+        '1': { start: { line: 1, column: 0 }, end: { line: 1 } },
+      },
+    };
+    const data = { MyClass: badItem };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item missing id field', () => {
+    const data = [{ ...validTestItem, id: undefined }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item missing name field', () => {
+    const data = [{ ...validTestItem, name: undefined }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item totalLines is not a number', () => {
+    const data = [{ ...validTestItem, totalLines: 'five' }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item lines has non-number value', () => {
+    const data = [{ ...validTestItem, lines: { '1': 'yes' } }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item lines is not an object', () => {
+    const data = [{ ...validTestItem, lines: 'not-an-object' }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns DeployCoverageData for empty object (isDeployCoverageData checks first)', () => {
+    // Empty object: Object.entries({}) is [], every() vacuously true -> DeployCoverageData
+    expect(checkCoverageDataType({} as DeployCoverageData)).toBe('DeployCoverageData');
+  });
+
+  it('returns Unknown when statementMap entry is null', () => {
+    const badItem = {
+      ...validDeployItem,
+      statementMap: { '1': null },
+    };
+    const data = { MyClass: badItem };
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item coveredPercent is not a number', () => {
+    const data = [{ ...validTestItem, coveredPercent: '80%' }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+
+  it('returns Unknown when test item totalCovered is not a number', () => {
+    const data = [{ ...validTestItem, totalCovered: null }];
+    expect(checkCoverageDataType(data as unknown as DeployCoverageData)).toBe('Unknown');
+  });
+});

--- a/test/units/setCoveredLines.test.ts
+++ b/test/units/setCoveredLines.test.ts
@@ -63,4 +63,41 @@ describe('setCoveredLines unit test', () => {
       sourceContent: fileContent,
     });
   });
+
+  it('does NOT remap an uncovered line (status=0) that is out of range', async () => {
+    mockGetTotalLines.mockResolvedValue(3);
+    // Line 10 is out of range but status=0: only covered (status=1) lines get remapped
+    const result = await setCoveredLines('some/file.cls', '/repo', { '10': 0 });
+    // status=0 out-of-range line stays in-place (not remapped)
+    expect(result).toEqual({ '10': 0 });
+  });
+
+  it('does NOT remap a line exactly equal to totalLines (lineNumber > totalLines is strict)', async () => {
+    mockGetTotalLines.mockResolvedValue(5);
+    // Line 5 is exactly at the boundary; 5 > 5 is false → stays in place
+    const result = await setCoveredLines('some/file.cls', '/repo', { '5': 1 });
+    expect(result).toEqual({ '5': 1 });
+  });
+
+  it('remaps a covered line one past the last (totalLines+1)', async () => {
+    mockGetTotalLines.mockResolvedValue(3);
+    // Line 4 > 3 → should be remapped to line 1
+    const result = await setCoveredLines('some/file.cls', '/repo', { '4': 1 });
+    expect(result).toEqual({ '1': 1 });
+  });
+
+  it('remaps a covered line to the last available slot (up to totalLines)', async () => {
+    mockGetTotalLines.mockResolvedValue(3);
+    // Lines 1 and 2 are used; out-of-range line 5 should remap to line 3
+    const result = await setCoveredLines('some/file.cls', '/repo', { '1': 1, '2': 1, '5': 1 });
+    expect(result).toEqual({ '1': 1, '2': 1, '3': 1 });
+  });
+
+  it('returns plain updatedLines when returnSourceContent is false (default)', async () => {
+    mockGetTotalLines.mockResolvedValue(3);
+    const result = await setCoveredLines('some/file.cls', '/repo', { '1': 1 }, false);
+    // Should be plain object, not { updatedLines, sourceContent }
+    expect(result).toEqual({ '1': 1 });
+    expect('updatedLines' in result).toBe(false);
+  });
 });

--- a/test/units/simplecovHandler.test.ts
+++ b/test/units/simplecovHandler.test.ts
@@ -1,0 +1,69 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { SimpleCovCoverageHandler } from '../../src/handlers/simplecov.js';
+
+describe('SimpleCovCoverageHandler unit tests', () => {
+  it('creates array with length equal to the max line number', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '5': 0 });
+    const result = handler.finalize();
+    expect(result.coverage['src/A.cls']).toHaveLength(5);
+  });
+
+  it('stores coverage at 0-indexed positions (line N → index N-1)', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '3': 0, '5': 1 });
+    const result = handler.finalize();
+    const arr = result.coverage['src/A.cls'];
+    expect(arr[0]).toBe(1); // line 1 → index 0
+    expect(arr[2]).toBe(0); // line 3 → index 2
+    expect(arr[4]).toBe(1); // line 5 → index 4
+  });
+
+  it('fills gaps between line numbers with null', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1, '5': 1 });
+    const result = handler.finalize();
+    const arr = result.coverage['src/A.cls'];
+    expect(arr[1]).toBeNull(); // line 2 (not in coverage data)
+    expect(arr[2]).toBeNull(); // line 3
+    expect(arr[3]).toBeNull(); // line 4
+  });
+
+  it('sorts coverage object by file path in finalize', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    const result = handler.finalize();
+    const keys = Object.keys(result.coverage);
+    expect(keys[0]).toBe('a/First.cls');
+    expect(keys[1]).toBe('z/Last.cls');
+  });
+
+  it('timestamp is a positive integer (seconds)', () => {
+    const handler = new SimpleCovCoverageHandler();
+    const result = handler.finalize();
+    expect(result.timestamp).toBeGreaterThan(0);
+    expect(Number.isInteger(result.timestamp)).toBe(true);
+  });
+
+  it('stores hit count (not just 0/1) at line index', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '2': 1, '3': 0 });
+    const result = handler.finalize();
+    const arr = result.coverage['src/A.cls'];
+    expect(arr[1]).toBe(1); // line 2 covered
+    expect(arr[2]).toBe(0); // line 3 uncovered
+  });
+
+  it('handles a single-line file', () => {
+    const handler = new SimpleCovCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    const arr = result.coverage['src/A.cls'];
+    expect(arr).toHaveLength(1);
+    expect(arr[0]).toBe(1);
+  });
+});

--- a/test/units/sonarHandler.test.ts
+++ b/test/units/sonarHandler.test.ts
@@ -1,0 +1,65 @@
+'use strict';
+
+import { describe, it, expect } from 'vitest';
+
+import { SonarCoverageHandler } from '../../src/handlers/sonar.js';
+
+describe('SonarCoverageHandler unit tests', () => {
+  it('sets @covered=true for lines with hit count 1', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '5': 1 });
+    const result = handler.finalize();
+    const lineToCover = result.coverage.file[0].lineToCover;
+    expect(lineToCover[0]['@covered']).toBe(true);
+  });
+
+  it('sets @covered=false for lines with hit count 0', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '5': 0 });
+    const result = handler.finalize();
+    const lineToCover = result.coverage.file[0].lineToCover;
+    expect(lineToCover[0]['@covered']).toBe(false);
+  });
+
+  it('records correct @lineNumber for each line', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/Foo.cls', 'Foo', { '10': 1, '20': 0, '30': 1 });
+    const result = handler.finalize();
+    const lineNumbers = result.coverage.file[0].lineToCover.map((l) => l['@lineNumber']);
+    expect(lineNumbers).toContain(10);
+    expect(lineNumbers).toContain(20);
+    expect(lineNumbers).toContain(30);
+  });
+
+  it('accumulates multiple files', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    handler.processFile('src/B.cls', 'B', { '2': 0 });
+    const result = handler.finalize();
+    expect(result.coverage.file).toHaveLength(2);
+  });
+
+  it('sorts files by @path in finalize', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('z/Last.cls', 'Last', { '1': 1 });
+    handler.processFile('a/First.cls', 'First', { '1': 1 });
+    handler.processFile('m/Middle.cls', 'Middle', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.coverage.file[0]['@path']).toBe('a/First.cls');
+    expect(result.coverage.file[1]['@path']).toBe('m/Middle.cls');
+    expect(result.coverage.file[2]['@path']).toBe('z/Last.cls');
+  });
+
+  it('version is set to "1"', () => {
+    const handler = new SonarCoverageHandler();
+    const result = handler.finalize();
+    expect(result.coverage['@version']).toBe('1');
+  });
+
+  it('produces no lineToCover entries for an empty lines object', () => {
+    const handler = new SonarCoverageHandler();
+    handler.processFile('src/Empty.cls', 'Empty', {});
+    const result = handler.finalize();
+    expect(result.coverage.file[0].lineToCover).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add 16 new test files and expand 2 existing ones targeting surviving mutants across all coverage format handlers and utility modules
- Current mutation score is ~68%; these tests are designed to reach ≥90%
- All 257 tests pass locally

## What's covered

**New handler tests (no prior direct tests):**
- `sonarHandler` — `@covered` true/false, line numbers, sort order
- `cloverHandler` — all metric fields (`@statements`, `@loc`, `@ncloc`, `@elements`, etc.), `@count`, `@type`
- `lcovHandler` — `hitCount` 0/1, `totalLines`/`coveredLines`, sort
- `jacocoHandler` — `@mi`/`@ci` flags, `@mb`/`@cb` always 0, counter accumulation, sort
- `istanbulHandler` — `statementMap` structure (column=0), `s`/`l` values, sort
- `simplecovHandler` — 0-indexed array, `null` gaps, `maxLine` size, sort, timestamp in seconds

**Expanded handler tests:**
- `coberturaHandlerExpanded` — `@hits`, `@branch`, `@line-rate`, `@branch-rate`, global accumulation
- `opencoverHandlerExpanded` — `@sequenceCoverage` calculation, `@vc`/`@sl`/`@el`, `@isConstructor`/`@isStatic`, UID reassignment
- `jsonSummaryExpanded` — sort order, statement mirroring, `skipped=0`

**Generator tests:**
- `generateHtmlUnit` — all three coverage colors (#4caf50/#ff9800/#f44336), `escapeHtml`, covered/uncovered class names, package summary table conditional
- `generateMarkdownUnit` — singular/plural "file", empty package/file tables, percentage format
- `generateGitHubActionsUnit` — singular/plural "file", `escapeProperty` (%, :, ,), `escapeData` (%)

**Utility/transformer tests:**
- `reportGeneratorUnit` — LCOV format strings (TN:/SF:/DA:/LF:/LH:/BRF:/BRH:/end_of_record), single vs multi-format filename suffix, XML headers (cobertura DOCTYPE, sonar no-DOCTYPE), `getExtensionForFormat`
- `setCoverageDataTypeExpanded` — valid deploy/test round-trips, missing fields, invalid positions
- `normalizePathToUnix` — backslash→forward slash, mixed, empty
- `getConcurrencyThreshold` — returns ≤6
- `setCoveredLines` (expanded) — status=0 not remapped, boundary `lineNumber === totalLines` not remapped, last slot reached
- `transform.test.ts` (expanded) — "None of the files processed" warning, `lineRate=0/minCoverage=0` strict-`<` boundary, `finalPaths` length, read-failure early return

## Test plan

- [x] `npx vitest run` passes all 257 tests locally
- [ ] CI mutation testing run shows score ≥ 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)