### PR TITLE
feat: log out-of-range covered line remappings at debug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,20 @@ Error (1): ENOENT: no such file or directory: {packageDir}
 
 **Deploy coverage line numbers** — The Salesforce CLI deploy coverage JSON contains known out-of-range line numbers. This plugin corrects them automatically by re-numbering covered lines; uncovered lines are unaffected. Test-command coverage is unaffected. See [forcedotcom/salesforcedx-vscode#5511](https://github.com/forcedotcom/salesforcedx-vscode/issues/5511) and [forcedotcom/cli#1568](https://github.com/forcedotcom/cli/issues/1568).
 
+To see each remapping, set `SF_LOG_LEVEL=debug` before running the command:
+
+```bash
+SF_LOG_LEVEL=debug sf acc-transformer transform -j "coverage/coverage/coverage.json" -r "coverage.xml" -f "sonar"
+```
+
+Each remapped line emits a log entry like:
+
+```
+Remapping out-of-range covered line 512 to line 47 in force-app/main/default/classes/AccountHandler.cls (file has 98 lines)
+```
+
+Logs are written to `~/.sf/sf-YYYY-MM-DD.log` by default. To print them to the terminal as well, set `DEBUG=sf:setCoveredLines`.
+
 ## License
 
 [MIT](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/LICENSE.md)

--- a/src/utils/setCoveredLines.ts
+++ b/src/utils/setCoveredLines.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { join } from 'node:path';
+import { Logger } from '@salesforce/core';
 import { getTotalLines } from './getTotalLines.js';
 
 export type SetCoveredLinesResult =
@@ -11,8 +12,9 @@ export async function setCoveredLines(
   filePath: string,
   repoRoot: string,
   lines: Record<string, number>,
-  returnSourceContent = false
+  returnSourceContent = false,
 ): Promise<SetCoveredLinesResult> {
+  const logger = await Logger.child('setCoveredLines');
   const result = await getTotalLines(join(repoRoot, filePath), returnSourceContent);
   const totalLines = typeof result === 'number' ? result : result.totalLines;
   const updatedLines: Record<string, number> = {};
@@ -26,6 +28,9 @@ export async function setCoveredLines(
     if (status === 1 && lineNumber > totalLines) {
       for (let randomLine = 1; randomLine <= totalLines; randomLine++) {
         if (!usedLines.has(randomLine)) {
+          logger.debug(
+            `Remapping out-of-range covered line ${lineNumber} to line ${randomLine} in ${filePath} (file has ${totalLines} lines)`,
+          );
           updatedLines[randomLine.toString()] = status;
           usedLines.add(randomLine);
           break;


### PR DESCRIPTION
## Summary

- Adds `Logger` from `@salesforce/core` to `setCoveredLines` and emits a `debug`-level log each time a deploy coverage line number exceeds the file's actual length and is remapped to an available in-range line
- Updates the README troubleshooting section (Deploy coverage line numbers) with instructions for enabling the log via `SF_LOG_LEVEL=debug` and `DEBUG=sf:setCoveredLines`, plus a sample log line

## Test plan

- [ ] Run `SF_LOG_LEVEL=debug sf acc-transformer transform -j <deploy-coverage.json> ...` against a project with known out-of-range deploy coverage lines and confirm log entries appear in `~/.sf/sf-YYYY-MM-DD.log`
- [ ] Confirm no log output when all covered lines are within file bounds
- [ ] Confirm existing unit tests for `setCoveredLines` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)