### PR TITLE
feat: expose min-coverage and max-annotations in hook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,13 +295,15 @@ Create `.apexcodecovtransformer.config.json` in the project root to transform co
 
 Sample configs: [Salesforce CLI](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/defaults/salesforce-cli/.apexcodecovtransformer.config.json), [SFDX Hardis](https://raw.githubusercontent.com/mcarvin8/apex-code-coverage-transformer/main/defaults/sfdx-hardis/.apexcodecovtransformer.config.json).
 
-| Key                        | Required   | Description                                                  |
-| -------------------------- | ---------- | ------------------------------------------------------------ |
-| `deployCoverageJsonPath`   | For deploy | Path to deploy coverage JSON.                                |
-| `testCoverageJsonPath`     | For test   | Path to test coverage JSON.                                  |
-| `outputReportPath`         | No         | Output path (default: `coverage.[xml/info/json]` by format). |
-| `format`                   | No         | Format(s), comma-separated (default: `sonar`).               |
-| `ignorePackageDirectories` | No         | Comma-separated package directories to ignore.               |
+| Key                        | Required   | Description                                                                                                         |
+| -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------- |
+| `deployCoverageJsonPath`   | For deploy | Path to deploy coverage JSON.                                                                                       |
+| `testCoverageJsonPath`     | For test   | Path to test coverage JSON.                                                                                         |
+| `outputReportPath`         | No         | Output path (default: `coverage.[xml/info/json]` by format).                                                        |
+| `format`                   | No         | Format(s), comma-separated (default: `sonar`).                                                                      |
+| `ignorePackageDirectories` | No         | Comma-separated package directories to ignore.                                                                      |
+| `minCoverage`              | No         | Minimum required line coverage percentage (0–100). Exits with an error if overall coverage is below this threshold. |
+| `maxAnnotations`           | No         | Maximum `::warning` annotations emitted when `format` includes `github-actions` (default: `50`).                    |
 
 ## Troubleshooting
 

--- a/defaults/salesforce-cli/.apexcodecovtransformer.config.json
+++ b/defaults/salesforce-cli/.apexcodecovtransformer.config.json
@@ -2,5 +2,7 @@
   "deployCoverageJsonPath": "coverage/coverage/coverage.json",
   "testCoverageJsonPath": "coverage/test-result-codecoverage.json",
   "outputReportPath": "coverage.xml",
-  "format": "sonar"
+  "format": "sonar",
+  "minCoverage": 75,
+  "maxAnnotations": 50
 }

--- a/defaults/sfdx-hardis/.apexcodecovtransformer.config.json
+++ b/defaults/sfdx-hardis/.apexcodecovtransformer.config.json
@@ -2,5 +2,7 @@
   "deployCoverageJsonPath": "hardis-report/apex-coverage-results.json",
   "testCoverageJsonPath": "hardis-report/apex-coverage-results.json",
   "outputReportPath": "coverage.xml",
-  "format": "sonar"
+  "format": "sonar",
+  "minCoverage": 75,
+  "maxAnnotations": 50
 }

--- a/src/hooks/finally.ts
+++ b/src/hooks/finally.ts
@@ -45,6 +45,8 @@ export const hook: Hook<'finally'> = async function (options) {
   const outputReport: string = configFile.outputReportPath || 'coverage.xml';
   const coverageFormat: string = configFile.format || 'sonar';
   const ignorePackageDirs: string = configFile.ignorePackageDirectories || '';
+  const minCoverage: number | undefined = configFile.minCoverage;
+  const maxAnnotations: number | undefined = configFile.maxAnnotations;
 
   if (commandType === 'deploy') {
     coverageJson = configFile.deployCoverageJsonPath || '.';
@@ -83,6 +85,14 @@ export const hook: Hook<'finally'> = async function (options) {
       commandArgs.push('--ignore-package-directory');
       commandArgs.push(sanitizedDir);
     }
+  }
+  if (minCoverage !== undefined) {
+    commandArgs.push('--min-coverage');
+    commandArgs.push(String(minCoverage));
+  }
+  if (maxAnnotations !== undefined) {
+    commandArgs.push('--max-annotations');
+    commandArgs.push(String(maxAnnotations));
   }
   await TransformerTransform.run(commandArgs);
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -68,6 +68,8 @@ export type HookFile = {
   outputReportPath: string;
   format: string;
   ignorePackageDirectories: string;
+  minCoverage?: number;
+  maxAnnotations?: number;
 };
 
 export type CoberturaLine = {


### PR DESCRIPTION
## Summary

- Adds optional `minCoverage` and `maxAnnotations` fields to `HookFile` type (`src/utils/types.ts`)
- Hook (`src/hooks/finally.ts`) now reads both fields and passes them as `--min-coverage` / `--max-annotations` when set
- Both sample default configs updated to show the new optional fields
- README hook config table updated with two new rows

## Test plan

- [ ] Add `"minCoverage": 75` to `.apexcodecovtransformer.config.json`, trigger a deploy/test hook, confirm command exits non-zero when coverage is below threshold
- [ ] Add `"maxAnnotations": 10` with `"format": "github-actions"`, confirm annotations are capped
- [ ] Omit both new fields, confirm existing hook behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)