### PR TITLE
test: address surviving mutants in format handlers

### DIFF
--- a/test/units/cloverHandler.test.ts
+++ b/test/units/cloverHandler.test.ts
@@ -117,4 +117,10 @@ describe('CloverCoverageHandler unit tests', () => {
     expect(m['@statements']).toBe(3);
     expect(m['@coveredstatements']).toBe(2);
   });
+
+  it('@clover version is "3.2.0"', () => {
+    const handler = new CloverCoverageHandler();
+    const result = handler.finalize();
+    expect(result.coverage['@clover']).toBe('3.2.0');
+  });
 });

--- a/test/units/coberturaHandlerExpanded.test.ts
+++ b/test/units/coberturaHandlerExpanded.test.ts
@@ -126,6 +126,18 @@ describe('CoberturaCoverageHandler expanded unit tests', () => {
     expect(pkg['@line-rate']).toBe(0.5);
   });
 
+  it('@version is "0.1" in the coverage element', () => {
+    const handler = new CoberturaCoverageHandler();
+    const result = handler.finalize();
+    expect(result.coverage['@version']).toBe('0.1');
+  });
+
+  it('sources.source is ["."] in the coverage element', () => {
+    const handler = new CoberturaCoverageHandler();
+    const result = handler.finalize();
+    expect(result.coverage.sources.source).toEqual(['.']);
+  });
+
   it('@line-rate sort callback correctly compares strings (ArrowFunction mutant killer)', () => {
     // The sort on packages uses a.localeCompare(b). Mutant replaces the arrow function body with undefined.
     // We test that after finalize, packages are in alphabetical order.

--- a/test/units/githubActions.test.ts
+++ b/test/units/githubActions.test.ts
@@ -228,6 +228,31 @@ describe('GitHubActionsCoverageHandler unit tests', () => {
   // Mutant replaces the initial coverageObj literal with {}. The finalize() call would fail
   // or produce undefined summaries.
 
+  // ── ConditionalExpression mutant killer (githubActions.ts:78 — if true) ──
+  // Mutant: always returns pathCompare (0 for same file) instead of falling through to lineNumber sort.
+  // Two separate processFile calls force insertion order [line 10, line 3] for the same file.
+  // A correct sort must swap them; the mutant returns 0 → stable sort → leaves them in wrong order.
+
+  it('sorts uncovered lines from same file even when inserted in descending order', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('a/File.cls', 'File', { '10': 0 });
+    handler.processFile('a/File.cls', 'File', { '3': 0 });
+    const result = handler.finalize();
+    expect(result.uncoveredLines.map((u) => u.lineNumber)).toEqual([3, 10]);
+  });
+
+  // ── ArithmeticOperator mutant killer (githubActions.ts:79 — a + b instead of a - b) ──
+  // Two processFile calls force insertion order [line 3, line 10] (already correct).
+  // Correct sort leaves them unchanged; a+b mutant returns 13 > 0 → swaps to [10, 3].
+
+  it('does not reverse same-file uncovered lines already in ascending order', () => {
+    const handler = new GitHubActionsCoverageHandler();
+    handler.processFile('a/File.cls', 'File', { '3': 0 });
+    handler.processFile('a/File.cls', 'File', { '10': 0 });
+    const result = handler.finalize();
+    expect(result.uncoveredLines.map((u) => u.lineNumber)).toEqual([3, 10]);
+  });
+
   it('finalize returns a properly structured object with summary and uncoveredLines', () => {
     const handler = new GitHubActionsCoverageHandler();
     handler.processFile('a/File.cls', 'File', { '1': 1, '2': 0 });

--- a/test/units/handlerRegistry.test.ts
+++ b/test/units/handlerRegistry.test.ts
@@ -53,6 +53,8 @@ describe('HandlerRegistry unit tests', () => {
     expect(HandlerRegistry.getExtension('html')).toBe('.html');
     expect(HandlerRegistry.getExtension('markdown')).toBe('.md');
     expect(HandlerRegistry.getExtension('github-actions')).toBe('.txt');
+    expect(HandlerRegistry.getExtension('clover')).toBe('.xml');
+    expect(HandlerRegistry.getExtension('jacoco')).toBe('.xml');
   });
 
   it('should return default extension for unknown format', () => {
@@ -183,6 +185,8 @@ describe('HandlerRegistry unit tests', () => {
     expect(p).toContain('Codecov');
     expect(p).toContain('Azure DevOps');
     expect(p).toContain('Jenkins');
+    expect(p).toContain('GitLab');
+    expect(p).toContain('GitHub Actions');
   });
 
   it('getAvailableFormats returns formats in sorted order', () => {
@@ -192,6 +196,29 @@ describe('HandlerRegistry unit tests', () => {
 
   it('error message for unknown format includes "Available formats"', () => {
     expect(() => HandlerRegistry.get('no-such-format-xyz')).toThrow('Available formats');
+  });
+
+  it('error message for unknown format uses comma-space as separator in available formats list', () => {
+    let message = '';
+    try {
+      HandlerRegistry.get('no-such-format-xyz');
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toMatch(/, /);
+  });
+
+  it('register does not throw for a unique handler name not already in the registry', () => {
+    const uniqueName = '__test-unique-handler-xyz__';
+    expect(() =>
+      HandlerRegistry.register({
+        name: uniqueName,
+        description: 'test handler',
+        fileExtension: '.test',
+        handler: () => new SonarCoverageHandler(),
+      }),
+    ).not.toThrow();
+    expect(HandlerRegistry.has(uniqueName)).toBe(true);
   });
 
   it('getExtension returns correct extension for cobertura', () => {

--- a/test/units/htmlHandler.test.ts
+++ b/test/units/htmlHandler.test.ts
@@ -245,6 +245,31 @@ describe('HTML coverage handler unit tests', () => {
     expect(result.summary.lineRate).toBe(0);
   });
 
+  // ── ArrayDeclaration mutant killer (html.ts:51 — else [] vs else ["Stryker was here"]) ──
+  // Mutant: when sourceContent is falsy, sourceLines = ["Stryker was here"] instead of [].
+  // For line 1, sourceLines[0] ?? '' gives "Stryker was here" instead of ''.
+
+  it('line content is empty string when no sourceContent is provided', () => {
+    const handler = getCoverageHandler('html');
+    handler.processFile('force-app/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize() as HtmlCoverageObject;
+    expect(result.files[0].lines[0].content).toBe('');
+  });
+
+  // ── StringLiteral mutant killer (html.ts:56 — ?? '' vs ?? "Stryker was here!") ──
+  // Mutant: when sourceLines[num-1] is undefined (line number beyond content), fallback is
+  // "Stryker was here!" instead of ''.
+
+  it('line content is empty string when line number exceeds sourceContent line count', () => {
+    const handler = getCoverageHandler('html');
+    // sourceContent has only 2 lines but coverage reports line 3
+    handler.processFile('force-app/A.cls', 'A', { '3': 1 }, 'line1\nline2');
+    const result = handler.finalize() as HtmlCoverageObject;
+    const line3 = result.files[0].lines.find((l) => l.lineNumber === 3);
+    expect(line3).toBeDefined();
+    expect(line3!.content).toBe('');
+  });
+
   it('calculates summary lineRate correctly across multiple files', () => {
     const handler = getCoverageHandler('html');
     handler.processFile('pkg/A.cls', 'A', { '1': 1, '2': 1 }); // 2/2

--- a/test/units/jacocoHandler.test.ts
+++ b/test/units/jacocoHandler.test.ts
@@ -113,4 +113,34 @@ describe('JaCoCoCoverageHandler unit tests', () => {
     const result = handler.finalize();
     expect(result.report['@name']).toBe('JaCoCo');
   });
+
+  it('package counter @type is "LINE"', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.report.package[0].counter[0]['@type']).toBe('LINE');
+  });
+
+  it('global report counter @type is "LINE"', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect(result.report.counter[0]['@type']).toBe('LINE');
+  });
+
+  // ── StringLiteral mutant killer (jacoco.ts:88 — localeCompare argument) ──
+  // Mutant: a['@name'].localeCompare(b[""]) where b[""] is always undefined → "undefined".
+  // Both 'D.cls' and 'A.cls' start with letters before 'u', so localeCompare('undefined')
+  // returns negative for both → comparator always returns negative → no swaps → insertion
+  // order preserved. Insertion order [D.cls, A.cls] must become [A.cls, D.cls] with correct sort.
+
+  it('sorts source files within a package correctly (localeCompare uses @name not empty key)', () => {
+    const handler = new JaCoCoCoverageHandler();
+    handler.processFile('force-app/classes/D.cls', 'D', { '1': 1 });
+    handler.processFile('force-app/classes/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    const names = result.report.package[0].sourcefile.map((sf) => sf['@name']);
+    expect(names[0]).toBe('A.cls');
+    expect(names[1]).toBe('D.cls');
+  });
 });

--- a/test/units/markdown.test.ts
+++ b/test/units/markdown.test.ts
@@ -200,6 +200,24 @@ describe('MarkdownCoverageHandler unit tests', () => {
 
   // ── ConditionalExpression mutation killer (markdown.ts:105 — always true) ──
 
+  // ── ConditionalExpression mutant killer (markdown.ts:105 — if true) ──
+  // Mutant: always executes lineRate comparison, skipping path tiebreak entirely.
+  // Files with EQUAL lineRates must be tiebroken by filePath.
+  // Inserted in wrong alphabetical order so the tiebreak changes the result.
+  // Mutant: lineRate equal → 0 → stable sort → insertion order preserved (wrong).
+
+  it('breaks ties by filePath when two files have the same lineRate', () => {
+    const handler = new MarkdownCoverageHandler();
+    // Both files have 1/2 = 50% coverage; insertion order is path-descending (Z before A)
+    handler.processFile('z-pkg/Z.cls', 'Z', { '1': 1, '2': 0 });
+    handler.processFile('a-pkg/A.cls', 'A', { '1': 1, '2': 0 });
+    const result = handler.finalize();
+    // Correct: tiebreak by path → 'a-pkg/A.cls' before 'z-pkg/Z.cls'
+    // Mutant (if true): lineRate equal → return 0 → stable → [Z, A] (wrong)
+    expect(result.files[0].filePath).toBe('a-pkg/A.cls');
+    expect(result.files[1].filePath).toBe('z-pkg/Z.cls');
+  });
+
   it('files with different lineRates are sorted by lineRate ascending (not always same order)', () => {
     const handler = new MarkdownCoverageHandler();
     // 100% covered

--- a/test/units/opencoverHandlerExpanded.test.ts
+++ b/test/units/opencoverHandlerExpanded.test.ts
@@ -130,6 +130,42 @@ describe('OpenCoverCoverageHandler expanded unit tests', () => {
   // with `["Stryker was here"]` — an array with one bogus string element.
   // The result would include that extra entry in SequencePoints.
 
+  // ── StringLiteral mutant killer (opencover.ts:83 — @hash value) ──
+
+  it('module @hash is "apex-module"', () => {
+    const handler = new OpenCoverCoverageHandler();
+    const result = handler.finalize();
+    expect(result.CoverageSession.Modules.Module[0]['@hash']).toBe('apex-module');
+  });
+
+  // ── StringLiteral mutant killer (opencover.ts:171 — summary[""] = 0 instead of @branchCoverage) ──
+  // Mutant sets an empty-string key on the summary object instead of '@branchCoverage'.
+  // Because @branchCoverage is already 0 from the constructor, the value looks the same.
+  // The distinguishing observable: the mutant adds a spurious "" property.
+
+  it('finalize does not add a spurious empty-string key to the summary object', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('src/A.cls', 'A', { '1': 1 });
+    const result = handler.finalize();
+    expect((result.CoverageSession.Summary as Record<string, unknown>)['']).toBeUndefined();
+  });
+
+  // ── StringLiteral mutant killer (opencover.ts:174 — localeCompare argument) ──
+  // Mutant: a['@fullName'].localeCompare(b[""]) where b[""] is always undefined → "undefined".
+  // Both 'DClass' and 'AClass' start with letters before 'u', so localeCompare('undefined')
+  // is always negative → comparator never swaps → insertion order [DClass, AClass] preserved.
+  // Correct sort must produce [AClass, DClass].
+
+  it('sorts classes by @fullName correctly (localeCompare uses @fullName not empty key)', () => {
+    const handler = new OpenCoverCoverageHandler();
+    handler.processFile('d/D.cls', 'DClass', { '1': 1 });
+    handler.processFile('a/A.cls', 'AClass', { '1': 1 });
+    const result = handler.finalize();
+    const classes = result.CoverageSession.Modules.Module[0].Classes.Class;
+    expect(classes[0]['@fullName']).toBe('AClass');
+    expect(classes[1]['@fullName']).toBe('DClass');
+  });
+
   it('sequence points only contain entries from the lines record (no spurious initial elements)', () => {
     const handler = new OpenCoverCoverageHandler();
     handler.processFile('a/A.cls', 'A', { '3': 1, '7': 0 });


### PR DESCRIPTION
## Summary

- Adds 17 targeted tests across 8 handler test files to kill Stryker mutants that survived the previous mutation test run
- Covers clover, cobertura, githubActions, HandlerRegistry, html, jacoco, markdown, and opencover handlers

## Mutants killed

| File | Mutant type | Technique |
|---|---|---|
| `clover.ts:28` | StringLiteral (`@clover` version) | Assert exact `'3.2.0'` value |
| `clover.ts:100` / `jacoco.ts:137` | StringLiteral (fileExtension) | Assert `getExtension()` returns `'.xml'` |
| `cobertura.ts:31` | StringLiteral (`@version`) | Assert exact `'0.1'` value |
| `cobertura.ts:32` | ObjectLiteral / ArrayDeclaration / StringLiteral (sources) | Assert `sources.source` equals `['.']` |
| `cobertura.ts:114` | StringLiteral (`GitLab`, `GitHub Actions`) | Assert all 5 `compatibleWith` entries |
| `githubActions.ts:78` | ConditionalExpression (`if true`) | Two separate `processFile` calls create insertion order `[10, 3]`; correct sort must swap |
| `githubActions.ts:79` | ArithmeticOperator (`a + b`) | Insertion order `[3, 10]` already correct; `a+b` mutant swaps them (wrong) |
| `HandlerRegistry.ts:65` | StringLiteral (`join` separator) | Assert error message matches `/, /` |
| `HandlerRegistry.ts:49` | ConditionalExpression (`if true` in register) | Assert registering a unique name does not throw |
| `html.ts:51` | ArrayDeclaration (else `[]`) | Assert `content === ''` when no `sourceContent` |
| `html.ts:56` | StringLiteral (`?? ''`) | Assert `content === ''` for out-of-bounds line numbers |
| `jacoco.ts:88` / `opencover.ts:174` | StringLiteral (localeCompare arg) | Names starting before `'u'` make broken comparator always return negative → no swaps → insertion order preserved (wrong) |
| `jacoco.ts:99` / `jacoco.ts:112` | StringLiteral (`@type`) | Assert `counter[0]['@type'] === 'LINE'` for package and global counters |
| `opencover.ts:83` | StringLiteral (`@hash`) | Assert `module['@hash'] === 'apex-module'` |
| `opencover.ts:171` | StringLiteral (`summary[""] = 0`) | Assert no empty-string key on summary object |

## Equivalent mutants (skipped — not killable via output)

- `cobertura.ts:33` — initial `packages.package` value (finalize overwrites it)
- `html.ts:43` — initial `packageSummaries` (finalize replaces entirely)
- `html.ts:53,64` — sort on `fileLines` (V8 already sorts integer object keys numerically)
- `html.ts:110` — `if (dirA !== dirB)` (dir prefix always gives same result as full-path sort)
- `jacoco.ts:31` — initial `package: []` in report (finalize rebuilds from sorted keys)
- `markdown.ts:42` — initial `packages: []` (finalize replaces entirely)
- `opencover.ts:107` — `fileIdCounter--` (UIDs are reassigned in finalize)

## Test plan

- [x] All 386 tests pass (`npx vitest run`)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)