### PR TITLE
chore(ci): remove duplicate workflow steps covered by wireit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Compile
-        run: npm run test:compile
-
       - name: Test
-        run: npm run test:only
+        run: npm run test
         env:
           SF_DISABLE_TELEMETRY: true
 
@@ -80,9 +77,6 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci
-
-      - name: Build
-        run: npm run build
 
       - name: Publish to NPM
         id: publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,11 +39,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Compile
-        run: npm run test:compile
-
       - name: Test
-        run: npm run test:only
+        run: npm run test
         env:
           SF_DISABLE_TELEMETRY: true
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "prepack": "wireit",
     "prepare": "husky install",
     "test": "wireit",
-    "test:compile": "wireit",
     "test:mutation": "stryker run",
     "test:mutation:incremental": "node scripts/incremental-mutation.mjs",
     "test:nuts": "wireit",


### PR DESCRIPTION
## Summary

- Replace explicit `test:compile` + `test:only` steps with `npm run test` in `test.yml` and `release.yml` unit-tests jobs — wireit already chains both as dependencies
- Drop redundant `npm run build` step before `npm publish` in release job — the publish lifecycle triggers `prepack` which triggers wireit `build`
- Remove `test:compile` from `package.json` scripts (still declared as a wireit dep, just not a direct entrypoint)

## Test plan

- [ ] CI passes on this PR (`test.yml` unit-tests + NUTs)
- [ ] Verify `npm run test` runs lint + test:compile + test:only via wireit

🤖 Generated with [Claude Code](https://claude.com/claude-code)