### PR TITLE
fix(ci): fix release tag order + catch up stale README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,20 @@ jobs:
           NODE_AUTH_TOKEN="" npm publish --access public --tag latest --provenance
           echo "published=true" >> "$GITHUB_OUTPUT"
 
+      # `npm publish` runs the `prepack` script (oclif manifest && oclif readme),
+      # which regenerates README.md's Command Reference against the version
+      # release-please just bumped. Push that back to main so the repo's README
+      # never drifts from what was just published. This must run BEFORE the tag
+      # move below: it leaves README.md modified but uncommitted in the working
+      # tree, and the repo's husky pre-push hook checks README.md is committed
+      # on every push (including a tag push) - pushing the tag first fails it.
+      - name: Commit regenerated README
+        if: steps.publish.outputs.published == 'true'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: regenerate command reference [skip ci]"
+          file_pattern: README.md
+
       # Moves a floating major-version tag (e.g. v3) to the release commit so
       # GitHub Action consumers can pin `uses: mcarvin8/apex-code-coverage-transformer@v3`
       # instead of an exact patch version.
@@ -95,17 +109,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -f "$MAJOR"
           git push origin "$MAJOR" --force
-
-      # `npm publish` runs the `prepack` script (oclif manifest && oclif readme),
-      # which regenerates README.md's Command Reference against the version
-      # release-please just bumped. Push that back to main so the repo's README
-      # never drifts from what was just published.
-      - name: Commit regenerated README
-        if: steps.publish.outputs.published == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "docs: regenerate command reference [skip ci]"
-          file_pattern: README.md          
 
   smoke-test:
     needs: release

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ EXAMPLES
   `sf acc-transformer transform -j "coverage1.json" -j "coverage2.json" -r "coverage.xml" -f "sonar"`
 ```
 
-_See code: [src/commands/acc-transformer/transform.ts](https://github.com/mcarvin8/apex-code-coverage-transformer/blob/v3.0.3/src/commands/acc-transformer/transform.ts)_
+_See code: [src/commands/acc-transformer/transform.ts](https://github.com/mcarvin8/apex-code-coverage-transformer/blob/v3.1.0/src/commands/acc-transformer/transform.ts)_
 <!-- commandsstop -->
 
 ## Coverage Report Formats


### PR DESCRIPTION
## Summary
The release job that ran after #376/#377 merged failed:

```
README.md command reference is out of date ('oclif readme' just regenerated it).
husky - pre-push script failed (code 1)
```

Root cause: `npm publish` runs the `prepack` lifecycle script (`oclif manifest && oclif readme`), which regenerates README.md's version-stamped "See code" link as a side effect - leaving it modified-but-uncommitted in the working tree. The "Move floating major version tag" step ran *before* "Commit regenerated README", so its `git push origin "$MAJOR"` tripped the repo's husky pre-push hook (which itself checks README.md is committed) and failed. Because of this, npm 3.1.0 published successfully but the README commit and the `v3` tag never landed.

- Reorders `release.yml` so the README commit happens before the tag move (also means the floating tag now points at the commit that includes the regen).
- Catches main up: regenerates README.md now (`v3.0.3` → `v3.1.0` link) so the pre-push hook stops blocking every push in the meantime.

## Test plan
- [x] `npx oclif readme` locally confirms README.md now matches the committed `3.1.0` version, no further diff
- [x] `git push` from this branch no longer trips the pre-push hook
- [ ] Next release run completes through the tag-move step without failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)