### PR TITLE
fix(action): shorten description for Marketplace's 125-char limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,5 @@
 name: 'Apex Code Coverage Transformer'
-description: >-
-  Transform Salesforce Apex code coverage JSON (from sf project deploy / sf apex run test) into
-  SonarQube, Cobertura, JaCoCo, LCOV, Clover, HTML, Markdown, GitHub Actions annotations, and more.
+description: 'Transform Salesforce Apex code coverage JSON into SonarQube, Cobertura, JaCoCo, LCOV, Clover, HTML, Markdown, and more.'
 author: 'Matt Carvin'
 branding:
   icon: 'percent'


### PR DESCRIPTION
## Summary
GitHub Marketplace blocked publishing with "Description must be less than 125 characters." Trimmed `action.yml`'s `description` from 195 to 119 chars (dropped the parenthetical CLI-command aside and the "GitHub Actions annotations" callout, kept the format list).

## Test plan
- [x] Description now 119 chars
- [ ] Re-check the "Publish this Action to the GitHub Marketplace" banner after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)