### PR TITLE
ci(release): auto-commit the Action bundle alongside the README regen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,19 +84,26 @@ jobs:
           NODE_AUTH_TOKEN="" npm publish --access public --tag latest --provenance
           echo "published=true" >> "$GITHUB_OUTPUT"
 
+      # Rebuilds the Action bundle in case a src/ change since the last release
+      # wasn't manually rebuilt-and-committed in its PR (CI's lint job catches
+      # this on the PR itself, but this keeps main self-healing regardless).
+      - name: Rebuild Action bundle
+        run: npm run build:action
+
       # `npm publish` runs the `prepack` script (oclif manifest && oclif readme),
       # which regenerates README.md's Command Reference against the version
-      # release-please just bumped. Push that back to main so the repo's README
-      # never drifts from what was just published. This must run BEFORE the tag
-      # move below: it leaves README.md modified but uncommitted in the working
-      # tree, and the repo's husky pre-push hook checks README.md is committed
-      # on every push (including a tag push) - pushing the tag first fails it.
-      - name: Commit regenerated README
+      # release-please just bumped. Push both that and the Action bundle rebuild
+      # above back to main so it never drifts from what was just published. This
+      # must run BEFORE the tag move below: it leaves README.md/dist/action
+      # modified but uncommitted in the working tree, and the repo's husky
+      # pre-push hook checks README.md is committed on every push (including a
+      # tag push) - pushing the tag first fails it.
+      - name: Commit regenerated README and Action bundle
         if: steps.publish.outputs.published == 'true'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "docs: regenerate command reference [skip ci]"
-          file_pattern: README.md
+          commit_message: "docs: regenerate command reference and Action bundle [skip ci]"
+          file_pattern: 'README.md dist/action/**'
 
       # Moves a floating major-version tag (e.g. v3) to the release commit so
       # GitHub Action consumers can pin `uses: mcarvin8/apex-code-coverage-transformer@v3`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ npm run build
 
 ## Git hooks (Husky)
 
-| Hook         | Runs            | What it does                                                                        |
-|--------------|-----------------|-------------------------------------------------------------------------------------|
-| `pre-commit` | on `git commit` | Runs `lint-staged` — applies Biome check + auto-fix to staged `.ts`/`.js` files     |
-| `commit-msg` | on `git commit` | Validates the commit message against Conventional Commits via commitlint            |
+| Hook         | Runs            | What it does                                                                                          |
+|--------------|-----------------|-------------------------------------------------------------------------------------------------------|
+| `pre-commit` | on `git commit` | Runs `lint-staged` — applies Biome check + auto-fix to staged `.ts`/`.js` files                       |
+| `commit-msg` | on `git commit` | Validates the commit message against Conventional Commits via commitlint                              |
 | `pre-push`   | on `git push`   | Runs `npm run readme` and fails if it produced an uncommitted change to README.md's Command Reference |
 
 ## Testing


### PR DESCRIPTION
## Summary
Regenerating `dist/action/index.cjs` after a `src/` change was entirely the PR author's responsibility - CI's `lint` job catches a stale bundle on the PR (blocking merge), but nothing fixed it automatically.

Mirrors the existing README auto-commit pattern in `release.yml`'s `release` job:
- New "Rebuild Action bundle" step runs `npm run build:action` unconditionally (cheap, matches how "Publish to NPM" already runs ungated).
- The existing "Commit regenerated README" step is renamed/widened to also pick up `dist/action/**` via `git-auto-commit-action`'s `file_pattern` (single bot commit for both, same as before).
- Ordering unchanged relative to the tag-move step (must still commit before pushing the `vN` tag, per the pre-push hook constraint from #378/#379).

This doesn't replace the PR-time CI check (still useful for contributor visibility/review) - it's a safety net so `main` self-heals even if that check gets missed or the bundle drifts for some other reason.

## Test plan
- Workflow-only change; will be exercised on the next actual release-please release. Reviewed step ordering against the existing tag-move constraint manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)