### PR TITLE
ci(release): keep dist/action fresh on every push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,41 @@ jobs:
         with:
           release-type: node
 
+  # Keeps dist/action/index.cjs current on every push to main, independent of
+  # whether this push is an actual release. A contributor's PR should already
+  # include a fresh bundle (enforced by test.yml's lint job), but this is the
+  # safety net: it ensures main is never stale by the time a maintainer merges
+  # the pending release-please PR, so release-please's own version tag (not
+  # just the floating major tag moved below) always includes a correct bundle.
+  # Race-free with release-please as long as maintainers let this job finish
+  # (and its commit, if any, land) before merging that PR - the release-please
+  # PR itself only touches version/changelog files, never src/, so it can't
+  # race with a bundle rebuild triggered by its own merge.
+  rebuild-dist:
+    name: Keep dist/action fresh
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Rebuild Action bundle
+        run: npm run build:action
+
+      - name: Commit if changed
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: rebuild Action bundle [skip ci]"
+          file_pattern: 'dist/action/**'
+
   unit-tests:
     name: Unit Tests (ubuntu-latest, node LTS)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Replaces the approach from the closed #384 (an inline "rebuild + commit" step gated inside the `release` job, only running on an actual release-please version bump) with a new `rebuild-dist` job that runs on **every** push to `main`, independent of whether it's a release.

Why: release-please creates its own version tag (e.g. `v3.1.3`) from the release-PR merge commit itself, before any later fix-up commit in the `release` job could land - so #384's approach could only ever heal the floating `v3` tag, never the exact-version tag. Keeping `main` continuously fresh (on every merge that touches `src/`) means that by the time a maintainer merges the pending release-please PR, `main` is already correct, and release-please's own tag is right from the start.

Race-free as long as maintainers let this job's commit (if any) land before merging the release-please PR - safe in practice since that PR only ever touches version/changelog files, never `src/`, so it can't itself trigger a bundle change to race against.

Runs parallel to `release-please` (no `needs:` dependency) since neither job depends on the other's output.

## Test plan
- [x] Validated YAML parses correctly and job graph is as expected (`release-please`, `rebuild-dist`, `unit-tests`, `release`, `smoke-test`)
- [ ] Will be exercised on the next push to main that changes `src/action`, `src/transformers`, `src/utils`, or `src/handlers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)