### PR TITLE
chore(lint): restrict CLI-only imports from the Action's bundled trees

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -126,6 +126,30 @@
       }
     },
     {
+      "includes": [
+        "src/action/**/*.ts",
+        "src/transformers/**/*.ts",
+        "src/utils/**/*.ts",
+        "src/handlers/**/*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "@salesforce/core": "This tree feeds the bundled GitHub Action (dist/action) and must stay dependency-free. Only node: builtins, relative imports, and @actions/core are allowed here.",
+                  "@salesforce/sf-plugins-core": "Same reason - CLI-only, bundling-unsafe.",
+                  "@oclif/core": "Same reason - CLI-only, bundling-unsafe."
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "includes": ["test/**/*.ts"],
       "javascript": {
         "globals": ["describe", "beforeAll", "beforeEach", "afterAll", "expect", "it", "afterEach", "vi", "test"]


### PR DESCRIPTION
## Summary
Follow-up guardrail from #386 - a Biome `noRestrictedImports` override scoped to exactly the trees `build:action` bundles into `dist/action/index.cjs` (`src/action/**`, `src/transformers/**`, `src/utils/**`, `src/handlers/**`). Blocks `@salesforce/core`, `@salesforce/sf-plugins-core`, and `@oclif/core` by name in those paths - still fully allowed in `src/commands/**`, which is untouched by this override.

Turns the class of bug fixed in #386 (`setCoveredLines.ts`'s accidental `@salesforce/core` import, which broke the shipped Action at runtime and was only caught once real fixture data happened to exercise that code path) into a lint error at the exact import site, instead of relying on bundle size or a smoke test to notice.

Known limitation: this is a named blocklist, not a "block anything non-portable" allowlist. A brand-new 4th runtime dependency wouldn't be caught unless added to this list too - acceptable given the current runtime dependency surface is exactly these 3 packages.

## Test plan
- [x] `npm run lint` passes clean on current `src/`
- [x] Manually verified the rule fires: temporarily reintroduced `import { Logger } from '@salesforce/core';` into `setCoveredLines.ts`, confirmed `npm run lint` failed on that exact line with the custom message, then reverted
- [x] `npx knip` and full `vitest run` (458/458) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)