### PR TITLE
test(action): cover the remaining branches in main.ts

### DIFF
--- a/test/units/action.test.ts
+++ b/test/units/action.test.ts
@@ -86,4 +86,27 @@ describe('GitHub Action entrypoint', () => {
 
     expect(core.setFailed).toHaveBeenCalledWith('The provided JSON does not match a known coverage data format.');
   });
+
+  it('defaults output-report to coverage.xml when the input is empty', async () => {
+    stubInputs({ 'output-report': '' }, { 'coverage-json': ['coverage.json'] });
+    transformMock.mockResolvedValue({ finalPaths: ['coverage.xml'], warnings: [], lineRate: 1, success: true });
+
+    await run();
+
+    expect(transformMock).toHaveBeenCalledWith(['coverage.json'], 'coverage.xml', ['sonar'], [], {
+      minCoverage: undefined,
+      maxAnnotations: undefined,
+      excludePatterns: [],
+    });
+  });
+
+  it('fails the action with String(error) when the thrown value is not an Error instance', async () => {
+    stubInputs({ 'output-report': 'coverage.xml' }, { 'coverage-json': ['coverage.json'] });
+    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
+    transformMock.mockRejectedValue('a plain string rejection');
+
+    await run();
+
+    expect(core.setFailed).toHaveBeenCalledWith('a plain string rejection');
+  });
 });


### PR DESCRIPTION
## Summary
Coverage report flagged `src/action/main.ts` at 80% branches (lines 21, 49 uncovered):
- Line 21: `core.getInput('output-report') || 'coverage.xml'` - the falsy-fallback branch, since every existing test explicitly set `output-report`.
- Line 49: `error instanceof Error ? error.message : String(error)` - the `String(error)` branch, since every existing rejection test used a real `Error` instance.

Added one test per branch. Full suite now at 100% statements/branches/functions/lines (791/280/194/735) per `vitest run --coverage`.

## Test plan
- [x] `npx vitest run --coverage` - 100% across all four metrics
- [x] `npm run lint` clean
- [x] `npx knip` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)